### PR TITLE
add default state for dev workflow

### DIFF
--- a/Magefile.go
+++ b/Magefile.go
@@ -113,13 +113,17 @@ func Bench(ctx context.Context, testSuite string) error {
 // Runs test suite on already running instance of grafana. Requires state for
 // operation
 func Test(ctx context.Context, testSuite string) error {
-	if BenchCfg.ProvisionState == "" {
-		return fmt.Errorf("invalid state: \"%s\"", BenchCfg.ProvisionState)
-	}
+	var ps *provisioner.ProvisionState
+	var err error
 
-	ps, err := BenchService.Provisioner.ReadStateFile(BenchCfg.ProvisionState)
-	if err != nil {
-		return err
+	if BenchCfg.ProvisionState != "" {
+		ps, err = BenchService.Provisioner.ReadStateFile(BenchCfg.ProvisionState)
+		if err != nil {
+			return err
+		}
+	} else {
+		// if no state provided, assume local driver, port 3000
+		ps = BenchService.Provisioner.NewLocalDevState(ctx)
 	}
 
 	// test the build

--- a/bench/provisioner/service.go
+++ b/bench/provisioner/service.go
@@ -77,10 +77,8 @@ func (p *ProvisionerService) New(ctx context.Context, t ProvisionType, build *bu
 
 	log.Info("provisioner: local path", "dir", localDir)
 
-	driver := p.InitDriver(t)
-
 	state := &ProvisionState{
-		driver:      driver,
+		driver:      p.InitDriver(t),
 		Identifier:  uuid.String(),
 		Type:        t,
 		LocalDir:    localDir,
@@ -107,6 +105,22 @@ func (p *ProvisionerService) New(ctx context.Context, t ProvisionType, build *bu
 	}
 
 	return state, nil
+}
+
+// NewLocalDevState creates a provision state assuming Grafana is running on
+// localhost:3000. Used for local development workflow. e.g. `mage test
+// dashboards` without providing a state
+func (p *ProvisionerService) NewLocalDevState(ctx context.Context) *ProvisionState {
+	return &ProvisionState{
+		driver:     p.InitDriver(Local),
+		Identifier: "LOCALDEVSTATE",
+		Type:       Local,
+		Build:      nil,
+		GrafanaInstance: &VMInstance{
+			Address:     "localhost",
+			ServicePort: "3000",
+		},
+	}
 }
 
 // Initializes provision driver from ProvisionType


### PR DESCRIPTION
Gives us the ability to run `mage test dashboards` and assumes Grafana is running on localhost:3000 if you don't set the STATE variable