### PR TITLE
Rewrite test runner as standalone binary

### DIFF
--- a/bench/provisioner/hg.go
+++ b/bench/provisioner/hg.go
@@ -72,12 +72,19 @@ func (d *HGDriver) Destroy(ctx context.Context, ps *ProvisionState) error {
 // specified and reports to k6 cloud
 func loadTest(ctx context.Context, ps *ProvisionState, tr *tester.TestRun, machineSpec string) error {
 	envVars := map[string]string{
-		"MACHINE_SPEC":            machineSpec,
-		"TEST_TYPE":               tr.Type.String(),
-		"TEST_SUITE_REVISION":     tr.SuiteRevision,
-		"GT_URL":                  ps.GrafanaInstance.SchemeServiceAddress(),
-		"GT_USERNAME":             ps.GrafanaInstance.ServiceUser,
-		"GT_PASSWORD":             ps.GrafanaInstance.ServicePassword,
+		"MACHINE_SPEC":        machineSpec,
+		"TEST_TYPE":           tr.Type.String(),
+		"TEST_SUITE_REVISION": tr.SuiteRevision,
+		"GRAFANA_URL":         ps.GrafanaInstance.SchemeServiceAddress(),
+		"GRAFANA_USERNAME":    ps.GrafanaInstance.ServiceUser,
+		"GRAFANA_PASSWORD":    ps.GrafanaInstance.ServicePassword,
+
+		// remove me after we update grafana/grafana-api-tests
+		"GT_URL":      ps.GrafanaInstance.SchemeServiceAddress(),
+		"GT_USERNAME": ps.GrafanaInstance.ServiceUser,
+		"GT_PASSWORD": ps.GrafanaInstance.ServicePassword,
+		//
+
 		"K6_CLOUD_TOKEN":          tr.K6CloudToken,
 		"K6_CLOUD_PROJECT_ID":     tr.K6CloudProjectId,
 		"K6_CLOUD_TRACES_ENABLED": "true",

--- a/bench/provisioner/service.go
+++ b/bench/provisioner/service.go
@@ -110,13 +110,15 @@ func (p *ProvisionerService) New(ctx context.Context, t ProvisionType, grafanaRe
 // NewLocalDevState creates a provision state assuming Grafana is running on https://localhost:3000. Used for local development workflow.
 // e.g. `mage test dashboards` without providing a state
 func (p *ProvisionerService) NewLocalDevState(ctx context.Context, grafanaAddress string, grafanaUser string, grafanaPassword string) *ProvisionState {
+
+	instance, _ := NewReadOnlyGrafanaVM(grafanaAddress, grafanaUser, grafanaPassword)
 	return &ProvisionState{
 		Log:              p.Log.With("driver", Local),
 		driver:           p.InitDriver(Local),
 		Identifier:       "LOCALDEVSTATE",
 		Type:             Local,
 		GrafanaBuildInfo: GrafanaBuildInfo{},
-		GrafanaInstance:  NewReadOnlyGrafanaVM(grafanaAddress, grafanaUser, grafanaPassword),
+		GrafanaInstance:  instance,
 	}
 }
 

--- a/bench/provisioner/vm.go
+++ b/bench/provisioner/vm.go
@@ -33,10 +33,10 @@ type VMInstance struct {
 // Takes a fully qualified address such as https://jefflevinslunch.grafana.net
 // and populates the service fields based on the address. If a port is not
 // included in the address, it will be determined based on the scheme
-func NewReadOnlyGrafanaVM(address, grafanaUser, grafanaPassword string) *VMInstance {
+func NewReadOnlyGrafanaVM(address, grafanaUser, grafanaPassword string) (*VMInstance, error) {
 	scheme, host, port, err := parseServiceAddress(address)
 	if err != nil {
-		panic(fmt.Errorf("error parsing grafana uri: %w", err))
+		return nil, fmt.Errorf("error parsing grafana uri: %w", err)
 	}
 
 	return &VMInstance{
@@ -45,7 +45,7 @@ func NewReadOnlyGrafanaVM(address, grafanaUser, grafanaPassword string) *VMInsta
 		ServiceScheme:   scheme,
 		ServiceUser:     grafanaUser,
 		ServicePassword: grafanaPassword,
-	}
+	}, nil
 }
 
 // parseServiceAddress takes an address such as

--- a/bench/tester/tester.go
+++ b/bench/tester/tester.go
@@ -71,6 +71,7 @@ func (tr *TestRun) ResolveTestSuite() error {
 	if !exists {
 		tr.Log.Info("cloning build suite")
 
+		// TODO remove dependency on mage.sh.RunV
 		if err := sh.RunV("git", "clone", tr.GrafanaTestRepo, tr.TestSuiteDir); err != nil {
 			return fmt.Errorf("test-run: Error checking out grafana test repo %s", err)
 		}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -57,7 +57,11 @@ func main() {
 func hgtest(ctx context.Context, log *slog.Logger, benchSvc *bench.BenchService, benchCfg *bench.BenchServiceCfg, testType, address, username, password, tests string) error {
 	log = log.With("svc", "hgtest")
 
-	grafanaInstance := provisioner.NewReadOnlyGrafanaVM(address, username, password)
+	grafanaInstance, err := provisioner.NewReadOnlyGrafanaVM(address, username, password)
+	if err != nil {
+		return err
+	}
+
 	provisioner.WaitForLiveGrafana(log, grafanaInstance.ServiceAddress())
 
 	grafanaVersion, err := provisioner.GetGrafanaBuildVersion(grafanaInstance)

--- a/cmd/runner/load.go
+++ b/cmd/runner/load.go
@@ -1,0 +1,1 @@
+package main

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"os"
+
+	"log/slog"
+
+	"github.com/grafana/grafana-bench/bench/provisioner"
+	"github.com/grafana/grafana-bench/bench/utils/env"
+)
+
+var benchRevision = "local"
+
+func main() {
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	log = log.With("svc", "init-test-runner")
+
+	// Setup bench service with defaults for CLI
+	if len(os.Args) != 6 {
+		log.Error("Missing parameters. need 6 args; testType grafanaAddress username password tests", "argCount", len(os.Args))
+
+		// one of these will panic and exit
+		log.Error("arg[0]", "exec", os.Args[0])
+		log.Error("arg[1]", "testType", os.Args[1])
+		log.Error("arg[2]", "address", os.Args[2])
+		log.Error("arg[4]", "username", os.Args[3])
+		log.Error("arg[4]", "password", os.Args[4])
+		log.Error("arg[5]", "tests", os.Args[5])
+	}
+
+	var (
+		testType = os.Args[1]
+		address  = os.Args[2]
+		username = os.Args[3]
+		password = os.Args[4]
+		tests    = os.Args[5]
+	)
+
+	trt, err := ParseTestType(testType)
+	if err != nil {
+		log.Error(err.Error())
+	}
+
+	grafanaInstance, err := provisioner.NewReadOnlyGrafanaVM(address, username, password)
+	if err != nil {
+		log.Error(err.Error())
+	}
+
+	runner := &TestRunner{
+		K6CloudToken:     env.EnvOrDefault("K6_CLOUD_TOKEN", ""),
+		K6CloudProjectID: env.EnvOrDefault("K6_CLOUD_PROJECT_ID", ""),
+		GrafanaInstance:  grafanaInstance,
+	}
+
+	log.Info("Bench run params",
+		"testType", trt.Name(),
+		"grafanaAddress", address,
+		"grafanaUser", username,
+		"tests", tests,
+		"k6ProjectId", runner.K6CloudProjectID,
+	)
+
+	// ENTRYPOINT to start actually running the tests
+	err = runner.Exec(trt)
+	if err != nil {
+		log.Error(err.Error())
+		os.Exit(1)
+	}
+}

--- a/cmd/runner/smoke.go
+++ b/cmd/runner/smoke.go
@@ -1,0 +1,1 @@
+package main

--- a/cmd/runner/test_type.go
+++ b/cmd/runner/test_type.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// This type setup uses a system that allows us to check test types at compile
+// time. Modeled after https://github.com/ardanlabs/service/blob/master/business/core/user/role.go
+
+var (
+	SmokeTest = TestType{"smoke"}
+	LoadTest  = TestType{"load"}
+)
+
+var testTypes = map[string]TestType{
+	SmokeTest.name: SmokeTest,
+	LoadTest.name:  LoadTest,
+}
+
+type TestType struct {
+	name string
+}
+
+// Name returns the name of the testType
+func (t TestType) Name() string {
+	return t.name
+}
+
+// Checks the testTypes map for valid testType
+func ParseTestType(value string) (TestType, error) {
+	testType, exists := testTypes[strings.ToLower(value)]
+	if !exists {
+		return TestType{}, fmt.Errorf("invalid testType %q", value)
+	}
+
+	return testType, nil
+}
+
+// MustParseTestType parses the string value and returns a testType if one exists. If
+// an error occurs the function panics.
+func MustParseTestType(value string) TestType {
+	testType, err := ParseTestType(value)
+	if err != nil {
+		panic(err)
+	}
+
+	return testType
+}
+
+// MarshalText implement the marshal interface for JSON conversions.
+func (t TestType) MarshalText() ([]byte, error) {
+	return []byte(t.name), nil
+}
+
+// Equal provides support for the go-cmp package and testing.
+func (t TestType) Equal(t2 TestType) bool {
+	return t.name == t2.name
+}
+
+type TestRunType string
+
+const (
+	// single iteration, fail slow, returns with exit code
+	Smoke TestRunType = "smoke"
+	// xxx iterations, don't fail, report to k6 cloud
+	Load TestRunType = "load"
+)
+
+func (trt TestRunType) String() string {
+	switch trt {
+	case Smoke:
+		return "smoke"
+	case Load:
+		return "load"
+	default:
+		panic("Unknown TestRunType")
+	}
+}
+
+// Gets the TestRunType from a string
+//func TestRunTypeFromString(trt string) (TestRunType, error) {
+//  trt = strings.ToLower(trt)
+//  switch trt {
+//  case "smoke":
+//    return Smoke, nil
+//  case "load":
+//    return Load, nil
+//  default:
+//    return nil, fmt.Sprintf("invalid test run type %s", trt)
+//  }
+//}

--- a/cmd/runner/tester.go
+++ b/cmd/runner/tester.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/grafana/grafana-bench/bench/provisioner"
+	"github.com/unknwon/log"
+)
+
+type TestRunner struct {
+	Log *slog.Logger
+	// location of test files on disk
+	TestDir string
+	// location of the .version file within the test repo
+	TestVersionFilepath string
+	K6CloudToken        string
+	K6CloudProjectID    string
+	GrafanaInstance     *provisioner.VMInstance
+
+	runIdentifier string
+}
+
+func NewTestRunner(ctx context.Context, log *slog.Logger, testDir string, testVersionFilepath string, k6CloudProjectId, k6CloudToken string, grafanaInstance *provisioner.VMInstance) *TestRunner {
+
+	return &TestRunner{
+		Log:                 log,
+		TestDir:             testDir,
+		TestVersionFilepath: testVersionFilepath,
+		K6CloudToken:        k6CloudToken,
+		K6CloudProjectID:    k6CloudProjectId,
+		GrafanaInstance:     grafanaInstance,
+	}
+}
+
+func (t *TestRunner) Exec(testType TestType) error {
+	ctx := context.Background()
+	log := t.Log.With("svc", "boot-test-runner")
+
+	// TODO implement a timeout of some sort
+	WaitForLiveGrafana(ctx, log, t.GrafanaInstance.ServiceAddress())
+
+	grafanaVersion, err := provisioner.GetGrafanaBuildVersion(t.GrafanaInstance)
+	if err != nil {
+		t.Log.Error("error getting grafana version", "err", err)
+		return fmt.Errorf("Error getting grafana version. exiting.. err: %w", err)
+	}
+
+	testVersion, err := t.GetShortTestRevisionFromCompiled(t.TestVersionFilepath)
+	if err != nil {
+		return err
+	}
+
+	t.runIdentifier = NewRunIdentifier(testType.Name(), grafanaVersion, testVersion)
+	t.Log.Info("suite identifier", "identifier", t.runIdentifier)
+
+	t.Log = log.With("svc", fmt.Sprintf("%s-test-runner", testType.Name()))
+
+	switch testType {
+	case SmokeTest:
+		return t.Smoke()
+	case LoadTest:
+		return t.Load()
+	}
+
+	return nil
+}
+
+// GetNewSuitedentifier creates an identifier to be used for
+// building dashboards in hosted grafana
+//
+// smoke-13:37:35-api-tests-cb5adc0-graf-10.2.0-60657
+// load-13:37:35-api-tests-cb5adc0-graf-10.2.0-60657
+func NewRunIdentifier(testType, grafanaVersion, testVersion string) string {
+	// {type}-{time}-api-tests-{sha}-graf-{version}
+	return fmt.Sprintf("%s-%s-api-tests-%s-graf-%s",
+		testType,
+		time.Now().UTC().Format("15:04:05"),
+		testVersion,
+		grafanaVersion,
+	)
+}
+
+// read .version from test directory
+func (t *TestRunner) GetShortTestRevisionFromCompiled(testVersionFilepath string) (string, error) {
+	bytes, err := os.ReadFile(testVersionFilepath)
+
+	if err == nil {
+		return strings.TrimSpace(string(bytes)), nil
+	}
+
+	if os.IsNotExist(err) {
+		t.Log.Warn(fmt.Sprintf("No version file specified at %s", testVersionFilepath))
+		return "UNKNOWN", nil
+	}
+
+	return "", err
+}
+
+// Wait for the server to start up
+func WaitForLiveGrafana(ctx context.Context, log *log.Slog, grafanaAddress string) {
+	for {
+		if IsLive(log, grafanaAddress) {
+			log.Info("Grafana server is ready!")
+			break
+		}
+		log.Info("Waiting for grafana server...", "address", grafanaAddress)
+		time.Sleep(time.Second)
+	}
+}
+
+func IsLive(log *slog.Logger, address string) bool {
+	_, err := net.Dial("tcp", address)
+	if err != nil {
+		log.Info("Checking isLive...", "error", err)
+	}
+	return err == nil
+}


### PR DESCRIPTION
This PR reworks the test runner as a separate library per https://github.com/grafana/grafana-bench/issues/98