### PR TITLE
Fix test folder in test logs

### DIFF
--- a/cmd/test/command.go
+++ b/cmd/test/command.go
@@ -5,13 +5,11 @@ import (
 	"log/slog"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/grafana/grafana-bench/bench"
 	"github.com/grafana/grafana-bench/bench/provisioner"
-	"github.com/grafana/grafana-bench/bench/utils"
 	"github.com/grafana/grafana-bench/bench/utils/env"
 	"github.com/spf13/cobra"
 )
@@ -86,14 +84,16 @@ func NewCmd(log *slog.Logger) *cobra.Command {
 				k6CloudProjectId = env.EnvOrDefault("K6_CLOUD_PROJECT_ID", "")
 			}
 
-			testSuitePath, testFiles, err := getTestFiles(testSuiteBase, testSuite)
-			if err != nil {
-				return fmt.Errorf("getting test files: %w", err)
+			// if the name of the test suite was not given, use the last element of the test suit path as name
+			if testSuiteName == "" {
+				testSuiteName = strings.TrimSuffix(path.Base(testSuite), ".js")
 			}
 
-			// if the name of the test suite was not given, use the last element of the test path as name
-			if testSuiteName == "" {
-				testSuiteName = strings.TrimSuffix(path.Base(testSuitePath), ".js")
+			if testSuiteBase == "" {
+				testSuiteBase, err = os.Getwd()
+				if err != nil {
+					return fmt.Errorf("getting work directory %w", err)
+				}
 			}
 
 			runner := NewTestRunner(
@@ -102,7 +102,8 @@ func NewCmd(log *slog.Logger) *cobra.Command {
 				k6CloudOutput,
 				testTrigger,
 				trt,
-				testFiles,
+				testSuiteBase,
+				testSuite,
 				testSuiteName,
 				testSuiteRevision,
 				k6CloudProjectId,
@@ -118,7 +119,6 @@ func NewCmd(log *slog.Logger) *cobra.Command {
 			log.Info(
 				"test runner params",
 				"testType", runner.Type.Name(),
-				"tests", runner.Tests,
 				"grafanaInstance", runner.GrafanaInstance.Host,
 				"k6ProjectId", runner.K6CloudProjectID,
 			)
@@ -149,10 +149,11 @@ func NewCmd(log *slog.Logger) *cobra.Command {
 		"\nExample: http://localhost/dashboards?run={{.SuiteRun}}",
 	)
 	fs.StringVar(&testSuite, "test-suite", "", "path to the tests to be executed."+
+	        "\nThe path must be relative to the base dir (which defaults to the current directory)." +
 		"\nA single .js file or a directory can be specified."+
 		"\nIf a directory is specified, all .js files in the directory and its sub-directories will be executed as tests.")
 	cmd.MarkFlagRequired("test-suite")
-	fs.StringVar(&testSuiteBase, "test-suite-base", "", "base directory for searching test suites."+
+	fs.StringVar(&testSuiteBase, "test-suite-base", "", "base directory for searching test suites. Defaults to current directory"+
 		"\nIf specified, it is prefixed to the --test-suite.")
 	fs.StringVar(&testSuiteName, "test-suite-name", "", "test suite name. If not specified, the last component of --test-suite will be used."+
 		"\nFor example --test-suite /path/to/testsuite will give a test suite name of 'testsuite'.")
@@ -169,47 +170,3 @@ func getTestSuiteRevision(revisionFile string) (string, error) {
 	return strings.TrimSpace(string(bytes)), nil
 }
 
-// getTestFiles returns the path to the test suite and the list of tests to execute.
-// The path prefixed with the basedir, which can be empty.
-// If tests points to a file with a js extension run that single file.
-// If it it points to a directory all of the .js files in it are recursively searched.
-// tests=dashboard_read.js will run dashboard_read.js.
-// tests=dashboards will run all files in dashboards/**.*.js.
-func getTestFiles(baseDir string, tests string) (string, []string, error) {
-	testSuitePath, err := filepath.Abs(path.Join(baseDir, tests))
-	if err != nil {
-		return "", nil, fmt.Errorf("getting path to test suite %w", err)
-	}
-
-	exists, _ := utils.PathExists(testSuitePath)
-	if !exists {
-		return "", nil, fmt.Errorf("test suite %s was not found", testSuitePath)
-	}
-
-	fileInfo, err := os.Stat(testSuitePath)
-	if err != nil {
-		return "", nil, fmt.Errorf("opening test suite at %s: %w", testSuitePath, err)
-	}
-
-	// test suite points to a directory
-	if fileInfo.IsDir() {
-		files, err := utils.GlobByExtension(testSuitePath, ".js")
-		if err != nil {
-			return "", nil, err
-		}
-
-		if len(files) == 0 {
-			return "", nil, fmt.Errorf("no test files found at %s", testSuitePath)
-		}
-
-		return testSuitePath, files, nil
-	}
-
-	// is a file, we expect a single .js file
-	testSuiteFile := path.Base(testSuitePath)
-	if !strings.HasSuffix(testSuiteFile, ".js") {
-		return "", nil, fmt.Errorf("expected a .js file got %s", testSuiteFile)
-	}
-
-	return testSuitePath, []string{testSuitePath}, nil
-}

--- a/cmd/test/runner.go
+++ b/cmd/test/runner.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-bench/bench/provisioner"
+	"github.com/grafana/grafana-bench/bench/utils"
 )
 
 type TestRunner struct {
@@ -22,9 +24,10 @@ type TestRunner struct {
 	RunIdentifier     string
 	Type              TestType
 	Trigger           string
+	TestSuiteBase     string
+	TestSuite         string
 	TestSuiteName     string
 	TestSuiteRevision string
-	Tests             []string
 	K6CloudToken      string
 	K6CloudProjectID  string
 	GrafanaInstance   *provisioner.VMInstance
@@ -41,7 +44,8 @@ func NewTestRunner(
 	cloudOutput bool,
 	testTrigger string,
 	testType TestType,
-	tests []string,
+	testSuiteBase string,
+	testSuite string,
 	testSuiteName,
 	testRevision string,
 	k6CloudProjectId,
@@ -58,7 +62,8 @@ func NewTestRunner(
 		K6CloudOutput:     cloudOutput,
 		Trigger:           testTrigger,
 		Type:              testType,
-		Tests:             tests,
+		TestSuiteBase:     testSuiteBase,
+		TestSuite:         testSuite,
 		TestSuiteName:     testSuiteName,
 		TestSuiteRevision: testRevision,
 		K6CloudToken:      k6CloudToken,
@@ -286,8 +291,12 @@ func (t *TestRunner) execTest(ctx context.Context, env map[string]string, args .
 		anyFailures   = false
 	)
 
+	tests, err := t.getTestFiles()
+	if err != nil {
+		return TestSuiteRunSummary{}, fmt.Errorf("getting test list: %w", err)
+	}
 	// run the tests
-	for iteration, testFile := range t.Tests {
+	for iteration, testFile := range tests {
 		scenarioName := getScenarioName(testFile)
 		// set the scenario name so it's accessible from the test
 		envVars["SCENARIO_NAME"] = scenarioName
@@ -311,11 +320,16 @@ func (t *TestRunner) execTest(ctx context.Context, env map[string]string, args .
 		totalDuration += k6Summary.Durations.TotalDuration
 		anyFailures = anyFailures || k6Summary.AnyFailures
 
+		// get the path to the test relative to the TestSuiteBase if any
+		// we don't need to check for errors because how the test path is constructed
+		rootDir, _ := filepath.Abs(t.TestSuiteBase)
+		testFolder, _  := filepath.Rel(rootDir, filepath.Dir(testFile))
+
 		// test complete log
 		testTags := []any{
 			"testRun", t.newTestIdentifier(testFile),
 			"scenarioName", scenarioName,
-			"folder", path.Dir(testFile),
+			"folder", testFolder,
 			"testFile", path.Base(testFile),
 			"order", strconv.Itoa(iteration + 1),
 		}
@@ -351,4 +365,52 @@ func (t *TestRunner) newTestIdentifier(filename string) string {
 		t.TestSuiteRevision,
 		t.GrafanaVersion,
 	)
+}
+
+// getTestFiles returns the list of tests to execute.
+// If tests points to a file with a js extension run that single file.
+// If it points to a directory all of the .js files in it are recursively searched.
+// tests=dashboard_read.js will run dashboard_read.js.
+// tests=dashboards will run all files in dashboards/**.*.js.
+func (t *TestRunner) getTestFiles() ([]string, error) {
+	if filepath.IsAbs(t.TestSuite) {
+		return nil, fmt.Errorf("test suite must be a relative to base dir. Got %q", t.TestSuite)
+	}
+
+	testSuitePath, err := filepath.Abs(path.Join(t.TestSuiteBase, t.TestSuite))
+	if err != nil {
+		return nil, fmt.Errorf("getting path to test suite %w", err)
+	}
+
+	exists, _ := utils.PathExists(testSuitePath)
+	if !exists {
+		return nil, fmt.Errorf("test suite %s not found", testSuitePath)
+	}
+
+	fileInfo, err := os.Stat(testSuitePath)
+	if err != nil {
+		return nil, fmt.Errorf("opening test suite at %s: %w", testSuitePath, err)
+	}
+
+	// test suite points to a directory
+	if fileInfo.IsDir() {
+		files, err := utils.GlobByExtension(testSuitePath, ".js")
+		if err != nil {
+			return nil, err
+		}
+
+		if len(files) == 0 {
+			return nil, fmt.Errorf("no test files found at %s", testSuitePath)
+		}
+
+		return files, nil
+	}
+
+	// is a file, we expect a single .js file
+	testSuiteFile := path.Base(testSuitePath)
+	if !strings.HasSuffix(testSuiteFile, ".js") {
+		return nil, fmt.Errorf("expected a .js file got %s", testSuiteFile)
+	}
+
+	return []string{testSuitePath}, nil
 }

--- a/cmd/test/runner_test.go
+++ b/cmd/test/runner_test.go
@@ -117,7 +117,7 @@ func WithInvalidDashboard() testRunnerOption {
 func testRunnerForTesting(
 	log *slog.Logger,
 	testType TestType,
-	tests []string,
+	testSuite string,
 	grafanaInstance *provisioner.VMInstance,
 	opts ...testRunnerOption,
 ) (*TestRunner, error) {
@@ -127,7 +127,8 @@ func testRunnerForTesting(
 		false,  // prevent sending output to cloud
 		"test", // trigger
 		testType,
-		tests,
+		"",        // base dir
+		testSuite, // test suite path
 		"test", // test suite name
 		"test", // test suite version
 		"",     // k6Cloud project
@@ -150,6 +151,8 @@ func testRunnerForTesting(
 
 const loginError = "Error logging into grafana instance"
 
+const testSuiteMissingError = "not found"
+
 const testSuiteFailedMessage = "test suite failed. Too many test failures"
 
 const cloudOutputDisabledMessage = "running load tests with cloud output disabled"
@@ -169,19 +172,19 @@ func Test_Runner(t *testing.T) {
 		testCase   string
 		options    []testRunnerOption
 		testType   TestType
-		tests      []string
+		testSuite  string
 		expectErr  string
 		expectMsgs []string
 	}{
 		{
-			testCase: "passing test (load)",
-			testType: SmokeTest,
-			tests:    []string{"k6tests/pass.js"},
+			testCase:  "passing test (load)",
+			testType:  SmokeTest,
+			testSuite: "k6tests/pass.js",
 		},
 		{
 			testCase:   "passing test without k6 token (smoke)",
 			testType:   LoadTest,
-			tests:      []string{"k6tests/pass.js"},
+			testSuite:  "k6tests/pass.js",
 			expectMsgs: []string{cloudOutputDisabledMessage},
 		},
 		{
@@ -190,7 +193,7 @@ func Test_Runner(t *testing.T) {
 				WithCloudOutput(),
 			},
 			testType:  LoadTest,
-			tests:     []string{"k6tests/pass.js"},
+			testSuite:  "k6tests/pass.js",
 			expectErr: missingK6CloudConfigError,
 		},
 		{
@@ -200,13 +203,13 @@ func Test_Runner(t *testing.T) {
 				WithInvalidK6Credentials(),
 			},
 			testType:   LoadTest,
-			tests:      []string{"k6tests/pass.js"},
+			testSuite:  "k6tests/pass.js",
 			expectMsgs: []string{cloudOutputParsingErrorMessage},
 		},
 		{
 			testCase:   "failing test (smoke)",
 			testType:   SmokeTest,
-			tests:      []string{"k6tests/fail.js"},
+			testSuite:  "k6tests/fail.js",
 			expectMsgs: []string{testSuiteFailedMessage},
 		},
 		{
@@ -215,7 +218,7 @@ func Test_Runner(t *testing.T) {
 				WithDashboard(),
 			},
 			testType: SmokeTest,
-			tests:    []string{"k6tests/fail.js"},
+			testSuite:  "k6tests/fail.js",
 			expectMsgs: []string{
 				testSuiteFailedMessage,
 				dashboardMessage,
@@ -227,18 +230,24 @@ func Test_Runner(t *testing.T) {
 			options: []testRunnerOption{
 				WithInvalidDashboard(),
 			},
-			tests:     []string{"k6tests/fail.js"},
+			testSuite:  "k6tests/fail.js",
 			expectErr: invalidDashboardError,
 		},
 		{
 			testCase: "failing test (load)",
 			testType: SmokeTest,
-			tests:    []string{"k6tests/fail.js"},
+			testSuite:  "k6tests/fail.js",
 		},
 		{
 			testCase:   "missing test (smoke)",
 			testType:   SmokeTest,
-			tests:      []string{"k6tests/missing.js"},
+			testSuite:  "k6tests/missing.js",
+			expectErr:  testSuiteMissingError,
+		},
+		{
+			testCase:   "test suite directory - one fails (smoke)",
+			testType:   SmokeTest,
+			testSuite:  "k6tests/",
 			expectMsgs: []string{testSuiteFailedMessage},
 		},
 		{
@@ -247,7 +256,7 @@ func Test_Runner(t *testing.T) {
 				WithInvalidGrafanaCredentials(),
 			},
 			testType:  SmokeTest,
-			tests:     []string{"k6tests/pass.js"},
+			testSuite: "k6tests/pass.js",
 			expectErr: loginError,
 		},
 	}
@@ -268,7 +277,7 @@ func Test_Runner(t *testing.T) {
 			tr, err := testRunnerForTesting(
 				log,
 				tc.testType,
-				tc.tests,
+				tc.testSuite,
 				grafanaInstance,
 				tc.options...,
 			)


### PR DESCRIPTION
Enforce a more strict semantic on the `test-suite-base` and `test-suite` parameters of the test runner to ensure the path to the test file (reported as `folder` in the test run summary) is consistent. 

`test-suite` is now always considered relative path to the `test-suite-base` (which is optional and defaults to the current working directory) 
 
Fixes #177 