### PR TITLE
Jalevin/push to gar

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,7 +94,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64 #,linux/arm64
           build-args: |
             BENCH_REVISION=${{ github.sha }}
           push: true


### PR DESCRIPTION
This PR adds the ability to push image to GAR. It also disables building arm and pushing to ghcr repository for now.