### PR TITLE
use a consistent suite run id

### DIFF
--- a/cmd/test/runner.go
+++ b/cmd/test/runner.go
@@ -140,7 +140,7 @@ func (t *TestRunner)getRunId(testType TestType) string {
 	)
 }
 
-// returns an unique id for the suite run
+// returns an unique id for the suite run (DEPRECATED)
 // format: {suite name}-{suite-revision}-graf-{grafana version}-{run-id}
 // Example api-tests-ee654f-graf-10.3-load-2024123-140035
 func (t *TestRunner) getSuiteRunId(runId string, suite TestSuite) string {


### PR DESCRIPTION
Generate an ID for each suite run (`runId`) that doesn't depend on the suite's name or revision and add the `suiteId` field that identifies the suite across runs. Following the ideas discussed in #199 

Maintains the `suiteRun` field for backward compatibility in the dashboards, but slightly changes the format for better legibility and easier ordering.


Suite Run
```
time=2024-04-11T09:24:36.102+02:00 level=INFO msg=suiteRun svc=test-runner runId=smoke-2024102-72433 suiteRun=api-tests-abcfe45-graf-11.1.0-69051-smoke-2024102-72433 testTrigger=local benchRevision=(devel) grafanaUrl=https://jefflevinslunch.grafana.net:443 grafanaVersion=11.1.0-69051 testExecutor=k6 suiteId=api-tests-abcfe45 suiteIdName=api-tests suiteRevision="abcfe45" startTime=0001-01-01T00:00:00Z totalScenarioDurations=0 duration=1306 testsExecuted=1 testsPassed=1 testsFailed=0 testsError=0 anyFailures=false
```

Test Run

```
time=2024-04-11T09:24:36.102+02:00 level=INFO msg=testRun svc=test-runner runId=smoke-2024102-72433 suiteRun=api-tests-abcfe45-graf-11.1.0-69051-smoke-2024102-72433 testTrigger=local benchRevision=(devel) grafanaUrl=https://jefflevinslunch.grafana.net:443 grafanaVersion=11.1.0-69051 testExecutor=k6 suiteId=api-tests-abcfe45 suiteIdName=api-tests suiteRevision="abcfe45" folder=cmd/test/k6tests testFile=pass.js order=1 iterations=1 setupDuration=0ms scenarioDuration=0ms teardownDuration=0ms totalDuration=0ms status=passed exitMessage="" exitCode=0 cloudId="" cloudURL="" testRun=smoke-2024102-72433-1
```

Fixes #199


