### PR TITLE
add suite status

### DIFF
--- a/cmd/test/executor.go
+++ b/cmd/test/executor.go
@@ -14,6 +14,14 @@ const (
        TestError   TestStatus = "error"
 )
 
+
+type SuiteStatus string
+
+const (
+       SuitePassed  SuiteStatus = "passed"
+       SuiteFailed  SuiteStatus = "failed"
+)
+
 // TestRun summarizes the execution of a test
 type TestRun struct {
 	TestFolder   string
@@ -31,6 +39,7 @@ type TestRun struct {
 // TestSuiteSummary summarizes the execution of  a test suite
 type SuiteRunSummary struct {
 	StartTime         time.Time
+	Status            SuiteStatus
 	TestsExecuted     int32
 	TestsFailed       int32
 	TestsPassed       int32

--- a/cmd/test/k6_executor.go
+++ b/cmd/test/k6_executor.go
@@ -162,6 +162,12 @@ func (t *K6TestExecutor) ExecTestSuite(
 		suiteSummary.TestRuns = append(suiteSummary.TestRuns, summary)
 	}
 
+	if suiteSummary.TestsPassed == suiteSummary.TestsExecuted {
+		suiteSummary.Status = SuitePassed
+	} else {
+		suiteSummary.Status = SuiteFailed
+	}
+
 	suiteSummary.ScenariosDuration = scenariosDuration
 	suiteSummary.TotalDuration = float32(time.Since(suiteStartTime).Milliseconds())
 

--- a/cmd/test/runner.go
+++ b/cmd/test/runner.go
@@ -98,6 +98,7 @@ func (t *TestRunner) Exec(ctx context.Context, testType TestType, suite TestSuit
 			Info("testRun", "testRun", testRunId)
 	}
 
+	// Deprecated. Use test suite summary's status field instead. Kept for backward compatibility
 	var anyFailures = (suiteRun.TestsFailed + suiteRun.TestsError) > 0
 
 	t.Log.With(t.testRunnerLogAttrs()...).
@@ -179,6 +180,7 @@ func suiteRunLogAttrs(suiteRun SuiteRunSummary) []any {
 		"startTime", suiteRun.StartTime.Format(time.RFC3339),
 		"totalScenarioDurations", suiteRun.ScenariosDuration,
 		"duration", suiteRun.TotalDuration,
+		"status", suiteRun.Status,
 		"testsExecuted", suiteRun.TestsExecuted,
 		"testsPassed", suiteRun.TestsPassed,
 		"testsFailed", suiteRun.TestsFailed,

--- a/cmd/test/runner_test.go
+++ b/cmd/test/runner_test.go
@@ -152,6 +152,7 @@ const (
 func failedSuiteSummary() SuiteRunSummary {
 	return SuiteRunSummary{
 		StartTime:     time.Now(),
+		Status:        SuiteFailed,
 		TestsExecuted: 1,
 		TestsFailed:   1,
 		TestRuns: []TestRun{
@@ -166,6 +167,7 @@ func failedSuiteSummary() SuiteRunSummary {
 func passingSuiteSummary() SuiteRunSummary {
 	return SuiteRunSummary{
 		StartTime:     time.Now(),
+		Status:        SuitePassed,
 		TestsExecuted: 1,
 		TestsPassed:   1,
 		TestRuns: []TestRun{


### PR DESCRIPTION
Reports the status (passed or failed) of the suite. 

This makes `anyFailures` field redundant but is kept for backward compatibility. 