### PR TITLE
clarify compile options

### DIFF
--- a/cmd/compile/command.go
+++ b/cmd/compile/command.go
@@ -16,9 +16,10 @@ bench compile --target-dir work/tests  \
 func NewCmd(log *slog.Logger) *cobra.Command {
 	log = log.With("svc", "test-compiler")
 	var (
-		targetDir         string
+		testSuiteDir      string
 		testSuiteRepo     string
 		testSuiteRevision string
+		forceCheckout     bool
 	)
 
 	cmd := cobra.Command{
@@ -29,9 +30,10 @@ func NewCmd(log *slog.Logger) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			compiler := NewTestCompiler(
 				log,
-				targetDir,
+				testSuiteDir,
 				testSuiteRepo,
 				testSuiteRevision,
+				forceCheckout,
 			)
 
 			return compiler.CompileTestSuite(cmd.Context())
@@ -40,13 +42,35 @@ func NewCmd(log *slog.Logger) *cobra.Command {
 
 	fs := cmd.Flags()
 	// FIXME: find a better name
-	fs.StringVar(&targetDir, "target-dir", "", "directory for checking the test into."+
-		"\nIf exists, it is assumed the test suite repository is already checked out in it.")
-	fs.StringVar(&testSuiteRepo, "test-suite-repo", "", "repository to grab test suite from")
-	fs.StringVar(&testSuiteRevision, "test-suite-revision", "", "test suite revision to compile."+
+	fs.StringVar(
+		&testSuiteDir,
+		"test-suite-dir", 
+		"",
+		"directory where the test suite repo is checkout."+
+		"\nIf the director exists and the test-suite-repo is specified, the repo will be checkout" +
+		"\nonly if the force-checkout option is set to true",
+	)
+	fs.StringVar(
+		&testSuiteRepo,
+		"test-suite-repo", 
+		"",
+		"repository to check out test suite from.",
+	)
+	fs.StringVar(
+		&testSuiteRevision,
+		"test-suite-revision",
+		"",
+		"test suite revision to compile."+
 		"\nCan make reference to a branch (local or remote), a tag or a specific commit hash"+
 		"\nIf not provided and the repo is already checked out in the base dir, the current branch is compiled."+
-		"\nOtherwise the main branch from the remote repository is compiled")
+		"\nOtherwise the main branch from the remote repository is compiled.",
+	)
+	fs.BoolVar(
+		&forceCheckout,
+		"force-checkout",
+		false,
+		"if the the test-suite-repo is specified and the test-suite-dir exists, indicates if the repo must be checkout",
+	)
 
 	return &cmd
 }

--- a/cmd/compile/compiler.go
+++ b/cmd/compile/compiler.go
@@ -17,23 +17,26 @@ import (
 // TestCompiler
 type TestCompiler struct {
 	Log               *slog.Logger
-	TargetDir         string
+	TestSuiteDir      string
 	TestSuiteRepo     string
 	TestSuiteRevision string
+	ForceCheckout     bool
 }
 
 
 func NewTestCompiler(
 	log *slog.Logger,
-	targetDir string,
+	testSuiteDir string,
 	testSuiteRepo string,
 	testSuiteRevision string,
+	forceCheckout bool,
 )  *TestCompiler {
 	return &TestCompiler{
 		Log:               log,
-		TargetDir:         targetDir,
+		TestSuiteDir:      testSuiteDir,
 		TestSuiteRepo:     testSuiteRepo,
 		TestSuiteRevision: testSuiteRevision,
+		ForceCheckout:     forceCheckout,
 	}
 }
 
@@ -44,10 +47,10 @@ func (tc *TestCompiler)CompileTestSuite(ctx context.Context) error {
 		err  error
 	)
 
-	// clone repo if doesn't exist
-	exists, _ := utils.PathExists(tc.TargetDir)
-	if exists {
-		repo, err = git.PlainOpen(tc.TargetDir)
+	// clone repo if doesn't exist or checkout is forced
+	exists, _ := utils.PathExists(tc.TestSuiteDir)
+	if exists && !tc.ForceCheckout {
+		repo, err = git.PlainOpen(tc.TestSuiteDir)
 		if err != nil {
 			return fmt.Errorf("opening repo %s: %w", tc.TestSuiteRepo, err)
 		}
@@ -55,7 +58,7 @@ func (tc *TestCompiler)CompileTestSuite(ctx context.Context) error {
 	} else {
 		tc.Log.Info("cloning test suite")
 		repo, err = git.PlainClone(
-			tc.TargetDir,
+			tc.TestSuiteDir,
 			false,
 			&git.CloneOptions{
 				URL:      tc.TestSuiteRepo,
@@ -125,7 +128,7 @@ func (tc *TestCompiler)CompileTestSuite(ctx context.Context) error {
 	}
 	
 	// build the tests
-	err = utils.DoInDir(workDir, tc.TargetDir, func() error {
+	err = utils.DoInDir(workDir, tc.TestSuiteDir, func() error {
 		cmdMake := exec.Command("make", "build")
 		if err := utils.ExecStdout(cmdMake); err != nil {
 			return fmt.Errorf("building test suite: %w", err)

--- a/cmd/compile/compiler_test.go
+++ b/cmd/compile/compiler_test.go
@@ -105,71 +105,81 @@ func Test_Compiler(t *testing.T) {
 	testCases := []struct{
 		name      string
 		repo      string
-		target    string
+		dir       string
 		revision  string
+		force     bool
 		expectErr bool
 	}{
 		{
-			name:      "reuse cloned repo",
-			repo:      "",
-			target:    clonedRepo,
+			name:      "reuse existing repo",
+			repo:      repoDir,
+			dir:       clonedRepo,
 			revision:  "master",
+			force:     false,
 			expectErr: false,
 		},
 		{
 			name:      "invalid local repo (not a git repo)",
 			repo:      "",
-			target:    t.TempDir(),
+			dir:       t.TempDir(),
 			revision:  "master",
+			force:     false,
 			expectErr: true,
 		},
 		{
 			name:      "build master",
 			repo:      repoDir,
-			target:    path.Join(t.TempDir(), "repo"),
+			dir:       path.Join(t.TempDir(), "repo"),
 			revision:  "master",
+			force:     false,
 			expectErr: false,
 		},
 		{
 			name:      "build default (master)",
 			repo:      repoDir,
-			target:    path.Join(t.TempDir(), "repo"),
+			dir:       path.Join(t.TempDir(), "repo"),
 			revision:  "",
+			force:     false,
 			expectErr: false,
 		},
 		{
 			name:      "build test branch",
 			repo:      repoDir,
-			target:    path.Join(t.TempDir(), "repo"),
+			dir:       path.Join(t.TempDir(), "repo"),
 			revision:  branchName,
+			force:     false,
 			expectErr: false,
 		},
 		{
 			name:      "build tag",
 			repo:      repoDir,
-			target:    path.Join(t.TempDir(), "repo"),
+			dir:       path.Join(t.TempDir(), "repo"),
 			revision:  tagName,
+			force:     false,
 			expectErr: false,
 		},
 		{
 			name:      "build hash",
 			repo:      repoDir,
-			target:    path.Join(t.TempDir(), "repo"),
+			dir:       path.Join(t.TempDir(), "repo"),
 			revision:  commitHash.String(),
+			force:     false,
 			expectErr: false,
 		},
 		{
 			name:      "build non-existing hash",
 			repo:      repoDir,
-			target:    path.Join(t.TempDir(), "repo"),
+			dir:       path.Join(t.TempDir(), "repo"),
 			revision:  "abcdef",
+			force:     false,
 			expectErr: true,
 		},
 		{
 			name:      "build non-existing branch",
 			repo:      repoDir,
-			target:    path.Join(t.TempDir()),
+			dir:       path.Join(t.TempDir()),
 			revision:  "fake-branch",
+			force:     false,
 			expectErr: true,
 		},
 	}
@@ -187,9 +197,10 @@ func Test_Compiler(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			compiler := NewTestCompiler(
 				log,
-				tc.target,
+				tc.dir,
 				tc.repo,
 				tc.revision,
+				tc.force,
 			)
 
 			err = compiler.CompileTestSuite(context.TODO())


### PR DESCRIPTION
Make compile command options easier to understand. 

- [ ] Check how this command is used when building the grafana-api-test images