### PR TITLE
return error on any failure

### DIFF
--- a/cmd/test/runner.go
+++ b/cmd/test/runner.go
@@ -106,22 +106,23 @@ func (t *TestRunner) Exec(ctx context.Context, testType TestType, suite executor
 		With(suiteRunLogAttrs(suiteRun)...).
 		Info("suiteRun", "anyFailures", anyFailures)
 
-	// NOTE this block of code performs substitution on a user defined url. e.g.
-	// http://mygrafana.com/b/?suiteRun={suiteRun}
-	// This functionality is ALPHA and may be removed in favor of outputting
-	// the suiteRun ID and leaving it up to the user.
 	if anyFailures {
-		var dashboardMsg string
+		dashboardMsg := ""
 		if t.DashboardURL != "" {
+			// NOTE this block of code performs substitution on a user defined url. e.g.
+			// http://mygrafana.com/b/?suiteRun={suiteRun}
+			// This functionality is ALPHA and may be removed in favor of outputting
+			// the suiteRun ID and leaving it up to the user.
 			dashboard, err := t.getDashboardURL(runId)
 			if err != nil {
-				return fmt.Errorf("getting URL dashboard: %w", err)
+				t.Log.With(t.testRunnerLogAttrs()...).
+					Error("getting URL dashboard: %w", err)
+			} else {
+				dashboardMsg = fmt.Sprintf(". See dashboard: %s", dashboard)
 			}
-			dashboardMsg = " See dashboard: " + dashboard
 		}
 
-		t.Log.With(suiteLogAttrs(suite)...).
-			Error("test suite failed. Too many test failures." + dashboardMsg)
+		return fmt.Errorf("test suite failed: Too many test failures%s", dashboardMsg)
 	}
 
 	return nil

--- a/cmd/test/runner_test.go
+++ b/cmd/test/runner_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -139,15 +140,16 @@ func testRunnerForTesting(
 }
 
 const (
+	invalidDashboardMessage = "invalid template substitution"
+
 	loginError = "Invalid credentials"
 
-	dashboardMessage = "See dashboard"
-
-	invalidDashboardError = "invalid template substitution"
-
-	testSuiteFailedMessage = "test suite failed. Too many test failures"
-
 	grafanaNotAliveError = "Instance not available"
+
+	testSuiteFailedError = "test suite failed: Too many test failures"
+
+	testSuiteFailedDashboardError = `test suite failed: Too many test failures.*See dashboard`
+
 )
 
 func failedSuiteSummary() executor.SuiteRunSummary {
@@ -196,10 +198,11 @@ func Test_Runner(t *testing.T) {
 			expectMsgs: []string{},
 		},
 		{
-			testCase:   "failing suite",
+			testCase:   "failing suite without dashboard",
 			instance:   newMockGrafanaInstance(),
 			summary:    failedSuiteSummary(),
-			expectMsgs: []string{testSuiteFailedMessage},
+			expectErr:  testSuiteFailedError,
+			expectMsgs: []string{},
 		},
 		{
 			testCase: "failing suite with dashboard",
@@ -208,10 +211,7 @@ func Test_Runner(t *testing.T) {
 			options: []testRunnerOption{
 				WithDashboard(),
 			},
-			expectMsgs: []string{
-				testSuiteFailedMessage,
-				dashboardMessage,
-			},
+			expectErr: testSuiteFailedDashboardError,
 		},
 		{
 			testCase: "failing suite with invalid dashboard",
@@ -220,7 +220,10 @@ func Test_Runner(t *testing.T) {
 			options: []testRunnerOption{
 				WithInvalidDashboard(),
 			},
-			expectErr: invalidDashboardError,
+			expectErr: testSuiteFailedError,
+			expectMsgs: []string{
+				invalidDashboardMessage,
+			},
 		},
 		{
 			testCase: "invalid credentials",
@@ -272,9 +275,8 @@ func Test_Runner(t *testing.T) {
 				t.Fatalf("should had failed with %q", tc.expectErr)
 			}
 
-			// FIXME: checking for specific error text is fragile.
-			// The TestRunner should return different error types to facilitate validations
-			if err != nil && (tc.expectErr == "" || !strings.Contains(err.Error(), tc.expectErr)) {
+			errExp := regexp.MustCompile(tc.expectErr)
+			if err != nil && !errExp.MatchString(err.Error()) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 


### PR DESCRIPTION
Return error to ensure the test run exits with a non-zero return code

Fixes #268 