### PR TITLE
set test suite revision from checked out repo

### DIFF
--- a/cmd/compile/command.go
+++ b/cmd/compile/command.go
@@ -45,7 +45,13 @@ func NewCmd(log *slog.Logger) *cobra.Command {
 				cmdArgs,
 			)
 
-			return compiler.CompileTestSuite(cmd.Context())
+			revision, err := compiler.CompileTestSuite(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			log.Info("checkout", "revision", revision)
+			return nil
 		},
 	}
 

--- a/cmd/test/command.go
+++ b/cmd/test/command.go
@@ -208,8 +208,12 @@ func NewCmd(log *slog.Logger) *cobra.Command {
 					[]string{},
 				)
 
-				if err := compiler.CompileTestSuite(context.TODO()); err != nil {
+				revision, err := compiler.CompileTestSuite(context.TODO())
+				if err != nil {
 					return fmt.Errorf("checking out test suite: %w", err)
+				}
+				if testSuiteRevision == "" {
+					testSuiteRevision = revision
 				}
 			}
 

--- a/pkg/compile/compiler.go
+++ b/pkg/compile/compiler.go
@@ -45,8 +45,9 @@ func NewTestCompiler(
 	}
 }
 
-// CompileTestSuite collects and builds tests from a source repository
-func (tc *TestCompiler)CompileTestSuite(ctx context.Context) error {
+// CompileTestSuite collect the test suite from a source repository
+// returns the test suite revision
+func (tc *TestCompiler)CompileTestSuite(ctx context.Context) (string, error) {
 	var (
 		repo *git.Repository
 		err  error
@@ -69,7 +70,7 @@ func (tc *TestCompiler)CompileTestSuite(ctx context.Context) error {
 	)
 
 	if err != nil {
-		return fmt.Errorf("checking out test suite repo %s: %w", tc.TestSuiteRepo, err)
+		return "", fmt.Errorf("checking out test suite repo %s: %w", tc.TestSuiteRepo, err)
 	}
 
 	// if we don't specify a revision, assume we want to run exactly what is
@@ -84,7 +85,7 @@ func (tc *TestCompiler)CompileTestSuite(ctx context.Context) error {
 		
 		branch, err = repo.Head()
 		if err != nil {
-			return fmt.Errorf("error getting current branch %w", err)
+			return "", fmt.Errorf("error getting current branch %w", err)
 		}
 
 		// if we are not in the requested branch
@@ -96,19 +97,19 @@ func (tc *TestCompiler)CompileTestSuite(ctx context.Context) error {
 				Auth: auth,
 			})
 			if err != nil  && !errors.Is(err, git.NoErrAlreadyUpToDate) {
-				return fmt.Errorf("fetching references %w", err)
+				return "", fmt.Errorf("fetching references %w", err)
 			}
 
 			var tree *git.Worktree
 
 			tree, err = repo.Worktree()
 			if err != nil {
-				return fmt.Errorf("getting work tree %w", err)
+				return "", fmt.Errorf("getting work tree %w", err)
 			}
 
 			revisionHash, err := repo.ResolveRevision(plumbing.Revision(tc.TestSuiteRevision))
 			if err != nil {
-				return fmt.Errorf("resolving reference to revision %q :%w", tc.TestSuiteRevision, err)
+				return "", fmt.Errorf("resolving reference to revision %q :%w", tc.TestSuiteRevision, err)
 			}
 
 			// FIXME: this only works for remote branches. Local branches are not found due to the reference 
@@ -116,15 +117,23 @@ func (tc *TestCompiler)CompileTestSuite(ctx context.Context) error {
 				Hash: *revisionHash,
 			})
 			if err != nil {
-				return fmt.Errorf("checking out test suite revision %q: %w", tc.TestSuiteRevision, err)
+				return "", fmt.Errorf("checking out test suite revision %q: %w", tc.TestSuiteRevision, err)
 			}
 		}
 	}
 
+	currentBranch, err := repo.Head()
+	if err != nil {
+		return "", fmt.Errorf("error getting current branch %w", err)
+	}
+
+	// set short revision
+	revisionHash := currentBranch.Hash().String()[1:7]
+
 	// update repo + checkout branch
 	workDir, err := os.Getwd()
 	if err != nil {
-		return fmt.Errorf("getting current work directory %w", err)
+		return "", fmt.Errorf("getting current work directory %w", err)
 	}
 
 	// build the tests
@@ -138,9 +147,8 @@ func (tc *TestCompiler)CompileTestSuite(ctx context.Context) error {
 			return nil
 		})
 
-		return err
+		return "", err
 	}
 
-	return nil
+	return revisionHash, nil
 }
-

--- a/pkg/compile/compiler_test.go
+++ b/pkg/compile/compiler_test.go
@@ -211,7 +211,7 @@ func Test_Compiler(t *testing.T) {
 				tc.prepareCmd,
 			)
 
-			err = compiler.CompileTestSuite(context.TODO())
+			_, err = compiler.CompileTestSuite(context.TODO())
 			if err != nil && !tc.expectErr {
 				t.Fatalf("compiling test: %v", err)
 			}


### PR DESCRIPTION
fixes #345 

```
grafana-bench  test --grafana-url https://jefflevinslunch.grafana.net/ --test-suite-repo https://github.com/grafana/grafana-api-tests ...

time=2024-08-12T12:03:04.883+02:00 level=INFO msg=suiteRun testTrigger=local benchRevision=(devel) grafanaUrl=jefflevinslunch.grafana.net grafanSlug=jefflevinslunch grafanaVersion=11.2.0-73830 testExecutor=k6 runId=smoke-2024225-10251 suiteRun=dashboards-e143e5-graf-11.2.0-73830-smoke-2024225-10251 suiteId=dashboards-e143e5 suiteIdName=dashboards suiteRevision=e143e5 startTime=2024-08-12T12:02:52+02:00 totalScenarioDurations=9031.283203125 duration=12245 testsExecuted=4 testsPassed=4 testsFailed=0 testsError=0 anyFailures=false
```