### PR TITLE
change format of test run id

### DIFF
--- a/cmd/report/report.go
+++ b/cmd/report/report.go
@@ -146,7 +146,7 @@ func NewCmd(log *slog.Logger) *cobra.Command {
 
 			runId = env.EnvOrDefault("RUN_ID", runId)
 			if runId == "" {
-				runId = id.GenRunId(time.Now(), testType)
+				runId = id.Run(trigger, time.Now())
 			}
 
 			err = suiteReporter.Report(
@@ -154,7 +154,7 @@ func NewCmd(log *slog.Logger) *cobra.Command {
 				testSuiteName,
 				testSuiteRevision,
 				runId,
-				getSuiteRunId(testSuiteName, testSuiteRevision, grafanaVersion, runId),
+				id.SuiteRunName(trigger, testSuiteName, testType),
 				suiteRun,
 			)
 			if err != nil {
@@ -242,19 +242,5 @@ func NewCmd(log *slog.Logger) *cobra.Command {
 		"prefix to append to the suite run metric names",
 	)
 
-
 	return &cmd
-}
-
-// FIXME: this is duplicated from pkg/runner/runner.go
-// returns an unique id for the suite run (DEPRECATED)
-// format: {suite name}-{suite-revision}-graf-{grafana version}-{run-id}
-// Example api-tests-ee654f-graf-10.3-load-2024123-140035
-func getSuiteRunId(suiteName, suiteRevision, grafanaVersion, runId string) string {
-	return fmt.Sprintf("%s-%s-graf-%s-%s",
-		suiteName,
-		suiteRevision,
-		grafanaVersion,
-		runId,
-	)
 }

--- a/cmd/test/command.go
+++ b/cmd/test/command.go
@@ -149,10 +149,30 @@ func NewCmd(log *slog.Logger) *cobra.Command {
 	}
 
 	fs := cmd.Flags()
-	fs.StringToStringVar(&config.EnvVars, "test-env-vars", nil, "custom test environment variables")
-	fs.StringVar(&config.Trigger, "test-trigger", "local", "test trigger")
-	fs.StringVar(&config.Type, "test-type", "smoke", "test type. Allowed values: 'smoke', 'load'")
-	fs.StringVar(&suiteConfig.TestExecutor, "test-runner", "k6", "test runner. Allowed values: 'k6', 'playwright'")
+	fs.StringToStringVar(
+		&config.EnvVars,
+		"test-env-vars",
+		nil,
+		"custom test environment variables",
+	)
+	fs.StringVar(
+		&config.Trigger,
+		"test-trigger",
+		"local",
+		"test trigger",
+	)
+	fs.StringVar(
+		&config.Type,
+		"test-type",
+		"smoke",
+		"test type. Allowed values: 'smoke', 'load'",
+	)
+	fs.StringVar(
+		&suiteConfig.TestExecutor,
+		"test-runner",
+		"k6",
+		"test runner. Allowed values: 'k6', 'playwright'",
+	)
 	fs.StringVar(
 		&config.PW.PrepareCmd,
 		"pw-prepare-cmd",
@@ -160,7 +180,12 @@ func NewCmd(log *slog.Logger) *cobra.Command {
 		"commands used to install dependencies for the test suite eg: \"npm install\"." +
 		"\nMultiple commands can be specified by separating with ';'.",
 	)
-	fs.StringVar(&config.PW.ExecuteCmd, "pw-execute-cmd", "", "command used to execute the test suite eg: \"npm run test\"")
+	fs.StringVar(
+		&config.PW.ExecuteCmd,
+		"pw-execute-cmd",
+		"",
+		"command used to execute the test suite eg: \"npm run test\"",
+	)
 	fs.StringVar(
 		&config.ReportFormat,
 		"test-report-format",
@@ -168,7 +193,12 @@ func NewCmd(log *slog.Logger) *cobra.Command {
 		"format of the test execution report. Allowed values 'log' or 'text'."+
 			"\n 'log' produced a structure log. 'text' produced an human readable output",
 	)
-	fs.BoolVar(&config.Verbose, "verbose", false, "show test outputs")
+	fs.BoolVar(
+		&config.Verbose,
+		"verbose",
+		false,
+		"show test outputs",
+	)
 	fs.StringVar(
 		&config.Grafana.Url,
 		"grafana-url",
@@ -200,13 +230,15 @@ func NewCmd(log *slog.Logger) *cobra.Command {
 		"",
 		"repository to get the test suite from. If not set TEST_SUITE_REPO environment variable is used."+
 			"\nIf specified, the repo will be checkout into the test-suite-base directory."+
-			"\nIf test-suite-revision is specified, that revision will be checkout. Otherwise the default branch will be checkout",
+			"\nIf test-suite-revision is specified, that revision will be checkout." +
+			"\nOtherwise the default branch will be checkout",
 	)
 	fs.StringVar(
 		&suiteConfig.RepoToken,
 		"test-suite-repo-token",
 		"",
-		"authentication token for the test suite repository. If not set TEST_SUITE_REPO_TOKEN environment variable is used.",
+		"authentication token for the test suite repository. " +
+		"\nIf not set TEST_SUITE_REPO_TOKEN environment variable is used.",
 	)
 	fs.StringSliceVar(
 		&suiteConfig.RepoDirs,
@@ -253,10 +285,14 @@ func NewCmd(log *slog.Logger) *cobra.Command {
 			"\n    SuiteRun: identifier of the suite run"+
 			"\nExample: http://localhost/dashboards?run={{.SuiteRun}}",
 	)
-	fs.StringVar(&suiteConfig.Path, "test-suite", "", "path to the tests to be executed."+
+	fs.StringVar(
+		&suiteConfig.Path,
+		"test-suite",
+		"",
+		"path to the tests to be executed."+
 		"\nThe path must be relative to the base dir (which defaults to the current directory)."+
 		"\nA single .js file or a directory can be specified."+
-		"\nIf a directory is specified, all .js files in the directory and its sub-directories will be executed.")
+		"\nIf a directory is specified, all files in the directory and its sub-directories will be executed.")
 	fs.StringVar(
 		&config.BaseDir,
 		"test-suite-base",

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -53,12 +53,13 @@ func (t *TestRunner) Exec(ctx context.Context, testType TestType, suite executor
 	var err error
 
 	// get an unique identification for the run
-	runId := t.getRunId(testType)
+	runId := id.Run(t.Trigger, time.Now())
 	t.Log = t.Log.With("runId", runId)
 
 	// get an unique identification for the suite run (used for backward compatibility)
-	suiteRunId := t.getSuiteRunId(runId, suite)
-	t.Log = t.Log.With("suiteRun", suiteRunId)
+	suiteRunName := id.SuiteRunName(t.Trigger, suite.Name, testType.Name())
+	// TODO: remove suiteRun
+	t.Log = t.Log.With("suiteRun", suiteRunName)
 
 	// set common test execution variables
 	env := map[string]string{
@@ -77,7 +78,7 @@ func (t *TestRunner) Exec(ctx context.Context, testType TestType, suite executor
 	}
 
 	// TODO: handle error from reporter
-	err = t.Reporter.Report(ctx, suite.Name, suite.Revision, runId, suiteRunId, suiteRun)
+	err = t.Reporter.Report(ctx, suite.Name, suite.Revision, runId, suiteRunName, suiteRun)
 	if err != nil {
 		t.Log.Error("reporting test suite run", "error", err)
 	}
@@ -101,23 +102,4 @@ func (t *TestRunner) Exec(ctx context.Context, testType TestType, suite executor
 	}
 
 	return nil
-}
-
-// returns an unique id for the run
-// format: {test type}-{year}{day of year}-{hour}{min}{second}
-// Example load-2024123-140035
-func (t *TestRunner) getRunId(testType TestType) string {
-	return id.GenRunId(time.Now().UTC(), testType.Name())
-}
-
-// returns an unique id for the suite run (DEPRECATED)
-// format: {suite name}-{suite-revision}-graf-{grafana version}-{run-id}
-// Example api-tests-ee654f-graf-10.3-load-2024123-140035
-func (t *TestRunner) getSuiteRunId(runId string, suite executor.TestSuite) string {
-	return fmt.Sprintf("%s-%s-graf-%s-%s",
-		suite.Name,
-		suite.Revision,
-		t.GrafanaVersion,
-		runId,
-	)
 }

--- a/pkg/utils/id/id.go
+++ b/pkg/utils/id/id.go
@@ -5,16 +5,23 @@ import (
 	"time"
 )
 
-// GenRunId returns an unique id for the run from the current time and the test type
-// format: {test type}-{year}{day of year}-{hour}{min}{second}
-// Example load-2024123-140035
-func GenRunId(time time.Time, testType string) string {
+// Run returns an unique id for the run from the pipeline and current time
+// format: {trigger}-{year}{day of year}-{hour}{min}{second}
+// Example rrc-dev-fast-6-2024123-140035
+func Run(trigger string, time time.Time) string {
 	return fmt.Sprintf("%s-%d%d-%d%d%d",
-		testType,
+		trigger,
 		time.Year(),
 		time.YearDay(),
 		time.Hour(),
 		time.Minute(),
 		time.Second(),
 	)
+}
+
+// SuiteRunName returns an unique id for the pipeline
+// format: {trigger}-{suite name}-{test type}
+// Example rrc-dev-fast-grafana/grafana-api-tests-load
+func SuiteRunName(trigger string, suiteName string, testType string) string {
+	return fmt.Sprintf("%s-%s-%s", trigger, suiteName, testType)
 }


### PR DESCRIPTION
Change the format of runId and suiteRunId

Run returns an unique id for the run from the pipeline and current time
format:  `{trigger}-{year}{day of year}-{hour}{min}{second}`
Example rrc-dev-fast-6-2024123-140035


Pipeline returns an unique id for the pipeline
format: {`trigger}-{suite name}-{test type}`
Example `rrc-dev-fast-grafana/grafana-api-tests-load`