### PR TITLE
fix missing service log attribute in log report

### DIFF
--- a/cmd/test/config.go
+++ b/cmd/test/config.go
@@ -151,7 +151,11 @@ func (config BenchConfig) BuildTestRunner(log *slog.Logger, testExecutor string)
 	var suiteReporter reporter.SuiteRunReporter
 	switch config.ReportFormat {
 	case "log":
-		suiteReporter = reporter.NewLogReporter(logAttrs)
+		// FIXME: this is a quick fix for the missing service attribute
+		// There's no way to get the attributes set in the runner's logger to be used
+		// in the reporter logger.
+		reporterAttrs := append(logAttrs, "service", "bench")
+		suiteReporter = reporter.NewLogReporter(reporterAttrs)
 	case "text":
 		suiteReporter = reporter.NewTextReporter(os.Stdout)
 	default:


### PR DESCRIPTION
Fixes: #463 