### PR TITLE
deps: update push-to-gar-docker to v0.4.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,7 +116,7 @@ jobs:
           persist-credentials: false
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
-      - uses: grafana/shared-workflows/actions/push-to-gar-docker@99afc12c9af11a4a8b89178197787e50b59d07f5 # v0.3.1
+      - uses: grafana/shared-workflows/actions/push-to-gar-docker@de81a07e6f6718fb289c7a4612c9c514c28bd798 # v0.4.1
         id: push-to-gar
         with:
           environment: "dev"
@@ -160,7 +160,7 @@ jobs:
           persist-credentials: false
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
-      - uses: grafana/shared-workflows/actions/push-to-gar-docker@99afc12c9af11a4a8b89178197787e50b59d07f5 # v0.3.1
+      - uses: grafana/shared-workflows/actions/push-to-gar-docker@de81a07e6f6718fb289c7a4612c9c514c28bd798 # v0.4.1
         id: push-to-gar
         with:
           environment: "prod"


### PR DESCRIPTION
Updates push-to-gar-docker to v0.4.1 to make it able to use Direct Workload Identity Federation, so no service account should be needed for this repository.

Part of: https://github.com/grafana/deployment_tools/issues/259653