### PR TITLE
remove warning for missing chromium path

### DIFF
--- a/pkg/executor/playwright/executor.go
+++ b/pkg/executor/playwright/executor.go
@@ -17,7 +17,6 @@ import (
 )
 
 const (
-	chromiumPath = "PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH"
 	ExecutorName = "playwright"
 )
 
@@ -62,13 +61,8 @@ func (t *PlaywrightTestExecutor) ExecTestSuite(
 		return executor.SuiteRunSummary{}, errMissingExecuteCmd
 	}
 
-	if os.Getenv(chromiumPath) == "" {
-		t.Log.Warn("playwright configuration", "environment variable not set", chromiumPath)
-	}
-
 	playwrightEnv := map[string]string{}
 	playwrightEnv["path"] = os.Getenv("PATH")
-	playwrightEnv[chromiumPath] = os.Getenv(chromiumPath)
 
 	maps.Copy(playwrightEnv, env)
 


### PR DESCRIPTION
We now expect users to configure playwright with `yarn install; yarn playwright install` and we are additionally basing the new bench-playwright image off of the official microsoft playwright image therefore I think this check is just creating noise.

fixes: https://github.com/grafana/grafana-bench/issues/602