### PR TITLE
bump alpine go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4.2-labs
 
-FROM golang:1.23-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 ARG BENCH_REVISION 
 ARG TARGETOS=linux

--- a/Dockerfile-playwright
+++ b/Dockerfile-playwright
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4.2-labs
 
-FROM golang:1.23-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 ARG BENCH_REVISION 
 ARG TARGETOS=linux

--- a/Dockerfile-playwright.dev
+++ b/Dockerfile-playwright.dev
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4.2-labs
 
-FROM golang:1.23-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 ARG BENCH_REVISION 
 ARG TARGETOS=linux

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4.2-labs
 
-FROM golang:1.23-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 ARG BENCH_REVISION 
 ARG TARGETOS=linux


### PR DESCRIPTION
Bump to go version 1.24 used in builds