### PR TITLE
GoExecutor: Break if failing test passes once and mark it as flaky

### DIFF
--- a/pkg/executor/gotest/executor.go
+++ b/pkg/executor/gotest/executor.go
@@ -92,6 +92,8 @@ func (e *GoExecutor) ExecTestSuite(
 					summary.TestRuns[i].Status = executor.TestFlaky
 					summary.TestsFailed--
 					summary.TestsFlaky++
+
+					break
 				}
 			}
 		}

--- a/pkg/executor/gotest/executor_test.go
+++ b/pkg/executor/gotest/executor_test.go
@@ -136,7 +136,7 @@ func TestFlakyTest(t *testing.T) {
 			title: "retry flaky test",
 			opts: GoExecutorOptions{
 				Packages: []string{"./..."},
-				Retries:  1,
+				Retries:  3,
 			},
 			suite: executor.TestSuite{
 				Path: "flaky",


### PR DESCRIPTION
If you set `--go-retries` > 1 with a flaky test, it will cause weird scenarios like the failed tests becoming negative if it succeeds at least 2.

We should `break` from the test the moment it succeeds, because we know that if it failed before and succeeded now, it is enough to mark it as flaky.

Updated one of the test cases to have >1 retries that simulates the issue. Without the `break` that was added, the test fails.