### PR TITLE
TextReporter: Use tabwriter for prettier output

### DIFF
--- a/pkg/reporter/text_reporter.go
+++ b/pkg/reporter/text_reporter.go
@@ -50,14 +50,14 @@ func (r *TextReporter) Report(
 			testRun.TestFolder,
 			testRun.TestFile,
 		)
-	
+
 		if testRun.Status == executor.TestPassed && testRun.Status != executor.TestSkipped {
 			continue
 		}
-	
+
 		// collect tests that didn't pass
 		tests := testsByStatus[testRun.Status]
-		tests = append( tests, fmt.Sprintf("%s:\t%s", testRun.TestFolder, testRun.TestFile))
+		tests = append(tests, fmt.Sprintf("%s:\t%s", testRun.TestFolder, testRun.TestFile))
 		testsByStatus[testRun.Status] = tests
 	}
 


### PR DESCRIPTION
New output looks like this:
```
[PASSED] 0.00 sec github.com/grafana/grafana/pkg/registry/apis/secret/encryption/cipher/provider/TestGcmDecryption/fails_if_secret_does_not_match
[PASSED] 0.00 sec github.com/grafana/grafana/pkg/registry/apis/secret/mutator/TestSecureValueMutator/when_operation_is_Delete
[PASSED] 0.00 sec github.com/grafana/grafana/pkg/registry/apis/secret/encryption/manager/TestEncryptionService_Decrypt/empty_payload_should_fail

--------------FLAKY TESTS--------------
github.com/grafana/grafana/pkg/registry/apis/secret/mutator: TestKeeperMutator/when_keeper_is_nil,_it_returns_an_error

--------------FAILED TESTS-------------
github.com/grafana/grafana/pkg/registry/apis/secret/mutator: TestKeeperMutator
github.com/grafana/grafana/pkg/registry/apis/secret/mutator: TestKeeperMutator/when_operation_is_Create_and_name_is_empty_without_GenerateName

----------------SUMMARY----------------
Executed:       202
Passed:         199
Flaky:          1
Failed:         2
Errors:         0
Suite:          
Total Run Time: 15.42 sec
```

Includes duration as well!