### PR TITLE
add workflow to update docs on release

### DIFF
--- a/.github/workflows/update-docs-on-release.yml
+++ b/.github/workflows/update-docs-on-release.yml
@@ -20,9 +20,10 @@ jobs:
           fetch-depth: 0  # Fetch all history for tags
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Generate updated documentation
         run: go run ./gendoc -o docs
@@ -41,20 +42,26 @@ jobs:
       - name: Get version and author info
         if: steps.check-changes.outputs.has_changes == 'true'
         id: get-info
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_AUTHOR: ${{ github.event.release.author.login }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_REF: ${{ github.ref }}
         run: |
-          if [ "${{ github.event_name }}" == "release" ]; then
-            VERSION="${{ github.event.release.tag_name }}"
-            AUTHOR="${{ github.event.release.author.login }}"
+          if [ "$EVENT_NAME" == "release" ]; then
+            VERSION="$RELEASE_TAG"
+            AUTHOR="$RELEASE_AUTHOR"
           else
             VERSION="${GITHUB_REF#refs/tags/}"
-            AUTHOR="${{ github.actor }}"
+            AUTHOR="$GITHUB_ACTOR"
           fi
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "author=${AUTHOR}" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
         if: steps.check-changes.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "docs: update documentation for ${{ steps.get-info.outputs.version }}"


### PR DESCRIPTION
This PR adds a workflow that submits a PR for documentation updates when we cut a new release of Bench.

Currently, if we cut a release, the next PR would be prompted for documentation updates that were just to update the version of bench referenced in the docs. This will instead immediately create a PR suggesting doc updates.