### PR TITLE
Fix release-binary workflow and update docs workflow

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -16,6 +16,8 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: grafana/setup-k6-action@v1
+
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod

--- a/.github/workflows/update-docs-on-release.yml
+++ b/.github/workflows/update-docs-on-release.yml
@@ -63,6 +63,7 @@ jobs:
         if: steps.check-changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
+          base: main
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "docs: update documentation for ${{ steps.get-info.outputs.version }}"
           title: "📚 Update documentation for ${{ steps.get-info.outputs.version }}"


### PR DESCRIPTION
This PR

 * adds k6 dependency for release-binary workflow.
 * fixes the base branch when creating a PR when updating docs on release