### PR TITLE
Install corepack and default versions of yarn and pnpm

### DIFF
--- a/Dockerfile-playwright
+++ b/Dockerfile-playwright
@@ -47,6 +47,13 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
+# Enable corepack and install pnpm (Node.js already included in Playwright base image)
+RUN npm uninstall -g yarn pnpm # remove default yarn and pnpm
+RUN npm install -g corepack@latest
+RUN corepack enable # enable corepack
+# install corepack packagemanagers
+RUN corepack install -g npm@latest yarn@latest pnpm@latest
+
 # Use existing pwuser from Playwright base image instead of creating bench user
 
 # Copy binaries

--- a/Dockerfile-playwright.dev
+++ b/Dockerfile-playwright.dev
@@ -49,6 +49,13 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
+# Enable corepack and install pnpm (Node.js already included in Playwright base image)
+RUN npm uninstall -g yarn pnpm # remove default yarn and pnpm
+RUN npm install -g corepack@latest
+RUN corepack enable # enable corepack
+# install corepack packagemanagers
+RUN corepack install -g npm@latest yarn@latest pnpm@latest
+
 # Use existing pwuser from Playwright base image instead of creating bench user
 
 # Copy binaries


### PR DESCRIPTION
This PR setups up corepack to handle installation of yarn and pnpm package managers.

This was done for the SLOs project as they rely on corepack for installing the correct version of pnpm, however, this is most likely the best strategy going forward as it allows teams to pin their package manager version in package.json with `  "packageManager": "pnpm@10.0.0"`