### PR TITLE
output json playwright data when parsing fails

### DIFF
--- a/cmd/report/report.go
+++ b/cmd/report/report.go
@@ -125,7 +125,7 @@ func NewCmd(log *slog.Logger) *cobra.Command {
 			var suiteRunSummary executor.SuiteRunSummary
 			switch benchConfig.Report.Input {
 			case "playwright":
-				suiteRunSummary, err = playwright.ParseJsonOutput(input)
+				suiteRunSummary, err = playwright.ParseJsonOutput(log, input)
 				if err != nil {
 					return fmt.Errorf("parsing playwright json input %w", err)
 				}

--- a/cmd/test/command.go
+++ b/cmd/test/command.go
@@ -281,7 +281,7 @@ func NewCmd(log *slog.Logger) *cobra.Command {
 				testEnvVars,
 			)
 			if err != nil {
-				return fmt.Errorf("executing test suite run %w", err)
+				return fmt.Errorf("executing test suite run: %w", err)
 			}
 
 			runMetrics, err := benchConfig.GetRunMetrics(log)

--- a/pkg/executor/playwright/executor.go
+++ b/pkg/executor/playwright/executor.go
@@ -103,7 +103,7 @@ func (t *PlaywrightTestExecutor) ExecTestSuite(
 	}
 
 	//parse output or report any problem
-	return ParseJsonOutput(jsonOutput)
+	return ParseJsonOutput(t.Log, jsonOutput)
 }
 
 func (t *PlaywrightTestExecutor) executeCommand(execDir string, env map[string]string, cmd string) error {

--- a/pkg/executor/playwright/parser.go
+++ b/pkg/executor/playwright/parser.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"path"
 	"strings"
 	"time"
@@ -15,7 +16,7 @@ import (
 
 // ParseJsonOutput parses the json output from playwright --report json and returns a slice of RunSummary
 // this will work if only one test is run and the output but will also work for if this contains an entire suite
-func ParseJsonOutput(report io.Reader) (executor.SuiteRunSummary, error) {
+func ParseJsonOutput(log *slog.Logger, report io.Reader) (executor.SuiteRunSummary, error) {
 	output := PlaywrightJsonOutput{}
 
 	buf, err := io.ReadAll(report)
@@ -25,6 +26,7 @@ func ParseJsonOutput(report io.Reader) (executor.SuiteRunSummary, error) {
 
 	err = json.Unmarshal(buf, &output)
 	if err != nil {
+		log.Error("invalid json output", "jsonOutput", string(buf))
 		return executor.SuiteRunSummary{}, fmt.Errorf("parsing Playwright json summary output: %w", err)
 	}
 
@@ -37,7 +39,7 @@ func ParseJsonOutput(report io.Reader) (executor.SuiteRunSummary, error) {
 	testRuns := parseSuites(output.Suites, testDirs, nil)
 
 	totalTestAmount := int32(output.Stats.Unexpected) + int32(output.Stats.Expected)
-	var suiteStatus executor.SuiteStatus = executor.SuitePassed
+	suiteStatus := executor.SuitePassed
 	if output.Stats.Unexpected > 0 {
 		suiteStatus = executor.SuiteFailed
 	}

--- a/pkg/executor/playwright/parser_test.go
+++ b/pkg/executor/playwright/parser_test.go
@@ -1,6 +1,7 @@
 package playwright
 
 import (
+	"log/slog"
 	"os"
 	"testing"
 	"time"
@@ -308,7 +309,7 @@ func TestParsePlaywrightJSONReport(t *testing.T) {
 				t.Fatalf("failed reading file: %s", err)
 			}
 
-			summary, err := ParseJsonOutput(file)
+			summary, err := ParseJsonOutput(&slog.Logger{}, file)
 			if err != nil {
 				t.Fatalf("failed parsing json file: %s", err)
 			}


### PR DESCRIPTION
Trying to debug playwright parsing failing as part of https://github.com/grafana/clickhouse-datasource/pull/1400. We're getting unexpected end of file, but have no idea why. This outputs the json data if there was an error.