### PR TITLE
Fix report args when test script is run with `npm run`

### DIFF
--- a/pkg/executor/playwright/executor.go
+++ b/pkg/executor/playwright/executor.go
@@ -92,17 +92,10 @@ func (t *PlaywrightTestExecutor) ExecTestSuite(
 	playwrightEnv["PLAYWRIGHT_JSON_OUTPUT_NAME"] = jsonOutput.Name()
 	t.Log.Debug("playwright output file", "PLAYWRIGHT_JSON_OUTPUT_NAME", jsonOutput.Name())
 
-	if strings.Contains(t.ExecuteCmd, "npm run") {
-		// npm needs the "--" to pass args to the script
-		t.ExecuteCmd = fmt.Sprintf("%s -- --reporter=json %s", t.ExecuteCmd, suite.Path)
-	} else {
-		// yarn and pnpm work as is
-		t.ExecuteCmd = fmt.Sprintf("%s --reporter=json %s", t.ExecuteCmd, suite.Path)
-	}
+	execCmd := appendReporterToCommand(t.ExecuteCmd, suite.Path)
+	t.Log.Debug("playwright command", "cmd", execCmd)
 
-	t.Log.Debug("playwright command", "cmd", t.ExecuteCmd)
-
-	if err := t.executeCommand(filepath.Join(suite.BaseDir, suite.Path), playwrightEnv, t.ExecuteCmd); err != nil {
+	if err := t.executeCommand(filepath.Join(suite.BaseDir, suite.Path), playwrightEnv, execCmd); err != nil {
 		// we can't tell if there was a error executing the test or the test command was wrong (e.g. misspelled)
 		// so we check if there's any report. If not, we assume the test was not executed and return
 		// otherwise we are trying to process the report with parseJsonOutput below
@@ -159,4 +152,12 @@ func (t *PlaywrightTestExecutor) executeCommand(execDir string, env map[string]s
 	}
 
 	return nil
+}
+
+func appendReporterToCommand(executeCmd string, suitePath string) string {
+	if strings.Contains(executeCmd, "npm run") {
+		return fmt.Sprintf("%s -- --reporter=json %s", executeCmd, suitePath)
+	}
+	// if using yarn/pnpm or others, just append normally
+	return fmt.Sprintf("%s --reporter=json %s", executeCmd, suitePath)
 }

--- a/pkg/executor/playwright/executor_test.go
+++ b/pkg/executor/playwright/executor_test.go
@@ -1,0 +1,55 @@
+package playwright
+
+import (
+	"testing"
+)
+
+func TestAppendReporterToCommand(t *testing.T) {
+	tests := []struct {
+		name       string
+		executeCmd string
+		suitePath  string
+		want       string
+	}{
+		{
+			name:       "npm run command",
+			executeCmd: "npm run test",
+			suitePath:  "tests",
+			want:       "npm run test -- --reporter=json tests",
+		},
+		{
+			name:       "npm run in longer command",
+			executeCmd: "NODE_ENV=ci npm run test:e2e",
+			suitePath:  "e2e",
+			want:       "NODE_ENV=ci npm run test:e2e -- --reporter=json e2e",
+		},
+		{
+			name:       "yarn command",
+			executeCmd: "yarn test",
+			suitePath:  "tests",
+			want:       "yarn test --reporter=json tests",
+		},
+		{
+			name:       "pnpm command",
+			executeCmd: "pnpm test",
+			suitePath:  "tests",
+			want:       "pnpm test --reporter=json tests",
+		},
+		{
+			name:       "other command",
+			executeCmd: "playwright test",
+			suitePath:  "tests",
+			want:       "playwright test --reporter=json tests",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := appendReporterToCommand(tt.executeCmd, tt.suitePath)
+			if got != tt.want {
+				t.Fatalf("appendReporterToCommand(%q, %q) = %q, want %q",
+					tt.executeCmd, tt.suitePath, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a `--` to the command string for running the Playwright suite when the command includes `npm run`. `npm run` does not forward arguments to the script in the same way `yarn` and `pnpm` does.