### PR TITLE
fix timeout when grafana unreachable

### DIFF
--- a/pkg/grafana/instance.go
+++ b/pkg/grafana/instance.go
@@ -226,7 +226,18 @@ func (g *grafanaInstance) getGrafanaSessionCookie() (*http.Cookie, error) {
 	for {
 		resp, err := client.Do(req)
 		if err != nil {
-			return nil, fmt.Errorf("request failed: %w", err)
+			// Check if we've exceeded the timeout
+			if time.Now().After(deadline) {
+				return nil, fmt.Errorf(
+					"%w timeout of '%.2fs' exceeded: request failed: %w",
+					InstanceNotAvailableError,
+					g.timeout.Seconds(),
+					err,
+				)
+			}
+			// Retry on connection errors (connection refused, etc.)
+			time.Sleep(g.backoff)
+			continue
 		}
 		defer resp.Body.Close()
 

--- a/pkg/grafana/instance_test.go
+++ b/pkg/grafana/instance_test.go
@@ -117,6 +117,11 @@ func Test_GetGrafanaSession(t *testing.T) {
 			expectErr: InstanceNotAvailableError,
 		},
 		{
+			testCase:  "connection retry on unreachable server",
+			mock:      nil, // No server started - will cause connection refused
+			expectErr: InstanceNotAvailableError,
+		},
+		{
 			testCase:  "login disabled",
 			mock:      newGrafanaMock(WithResponse("POST", "/login", loginDisbledHandler)),
 			expectErr: LoginDisableError,
@@ -127,8 +132,18 @@ func Test_GetGrafanaSession(t *testing.T) {
 		tc := tc
 		t.Run(tc.testCase, func(t *testing.T) {
 			t.Parallel()
-			mockServer := httptest.NewServer(tc.mock)
-			instance, err := NewInstance(mockServer.URL, "admin", "admin", WithTimeout(time.Second*3))
+			
+			var instance GrafanaInstance
+			var err error
+			
+			if tc.mock == nil {
+				// Test connection refused - use invalid URL
+				instance, err = NewInstance("http://localhost:0", "admin", "admin", WithTimeout(time.Second*3))
+			} else {
+				mockServer := httptest.NewServer(tc.mock)
+				instance, err = NewInstance(mockServer.URL, "admin", "admin", WithTimeout(time.Second*3))
+			}
+			
 			if err != nil {
 				t.Fatalf("unexpected error in test setup %v", err)
 			}


### PR DESCRIPTION
Fix bug where we weren't retrying when instance was not available.