### PR TITLE
Use gh CLI to download release binaries, go install for latest

### DIFF
--- a/.github/actions/setup-grafana-bench/action.yml
+++ b/.github/actions/setup-grafana-bench/action.yml
@@ -7,28 +7,14 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Setup Go
-      if: inputs.version == 'latest'
-      uses: actions/setup-go@v5
-      with:
-        go-version: '>=1.23.x'
-        cache: false
-
-    - name: Install grafana-bench
+    - name: Download grafana-bench binary
+      id: download
       if: inputs.version != 'false'
       shell: bash
       env:
         VERSION: ${{ inputs.version }}
         GH_TOKEN: ${{ github.token }}
       run: |
-        if [ "$VERSION" = "latest" ]; then
-          git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
-          GOPRIVATE="github.com/grafana/grafana-bench" GOPROXY="direct" GOSUMDB="off" \
-            go install "github.com/grafana/grafana-bench@latest"
-          grafana-bench version
-          exit 0
-        fi
-
         OS=$(uname -s | tr '[:upper:]' '[:lower:]')
         ARCH=$(uname -m)
 
@@ -48,14 +34,40 @@ runs:
         BINARY_NAME="grafana-bench-${PLATFORM}-${ARCH}"
         echo "Downloading $BINARY_NAME from release $VERSION..."
 
-        gh release download "${VERSION}" \
+        if gh release download "${VERSION}" \
           --repo grafana/grafana-bench \
           --pattern "${BINARY_NAME}" \
-          --output grafana-bench
+          --output grafana-bench 2>/dev/null; then
+          chmod +x grafana-bench
+          sudo mv grafana-bench /usr/local/bin/
+          echo "installed=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "No binary found for $VERSION, will fall back to go install"
+          echo "installed=false" >> "$GITHUB_OUTPUT"
+        fi
 
-        chmod +x grafana-bench
-        sudo mv grafana-bench /usr/local/bin/
-        grafana-bench version
+    - name: Setup Go
+      if: inputs.version != 'false' && steps.download.outputs.installed == 'false'
+      uses: actions/setup-go@v5
+      with:
+        go-version: '>=1.23.x'
+        cache: false
+
+    - name: Install grafana-bench via go install
+      if: inputs.version != 'false' && steps.download.outputs.installed == 'false'
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
+        GOPRIVATE="github.com/grafana/grafana-bench" GOPROXY="direct" GOSUMDB="off" \
+          go install "github.com/grafana/grafana-bench@${VERSION}"
+
+    - name: Verify grafana-bench installation
+      if: inputs.version != 'false'
+      shell: bash
+      run: grafana-bench version
     - id: get-secrets
       uses: grafana/shared-workflows/actions/get-vault-secrets@078c4a8af09e06d646077550f9e0f68171d5881e
       with:


### PR DESCRIPTION
Curl command lacks auth, however, if we switch to GH we don't have to parse with jq after. This makes the workflow cleaner and also has better support for auth plumbing.