### PR TITLE
fix(slack): surface not_in_channel errors and fix nil dereference in validate

### DIFF
--- a/pkg/notifier/slack_notifier_test.go
+++ b/pkg/notifier/slack_notifier_test.go
@@ -24,12 +24,14 @@ type mockServer struct {
 	mutext   *sync.Mutex
 	channels map[string]string
 	messages map[string][]string
+	apiErr   string // if non-empty, chat.postMessage returns this Slack API error
 }
 
-func newMockServer() *mockServer {
+func newMockServerWithError(apiErr string) *mockServer {
 	return &mockServer{
 		mutext:   &sync.Mutex{},
 		messages: map[string][]string{},
+		apiErr:   apiErr,
 	}
 }
 
@@ -46,9 +48,22 @@ func (m *mockServer) Messages(channel string) []string {
 // server. It takes the channel, channel_id, and text form values and
 // stores them in the messages map. It then responds with a JSON object
 // that contains the channel, ts, and text.
+// If the server was configured with an apiErr, it returns an error response instead.
 func (m *mockServer) HandleChatPostMessage(w http.ResponseWriter, r *http.Request) {
 	m.mutext.Lock()
 	defer m.mutext.Unlock()
+
+	if m.apiErr != "" {
+		resp := &struct {
+			Ok    bool   `json:"ok"`
+			Error string `json:"error"`
+		}{
+			Ok:    false,
+			Error: m.apiErr,
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+		return
+	}
 
 	channel := r.FormValue("channel")
 	text := r.FormValue("text")
@@ -69,12 +84,12 @@ func (m *mockServer) HandleChatPostMessage(w http.ResponseWriter, r *http.Reques
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
-// TODO: test errors from slack server
 func TestNotify(t *testing.T) {
 	testCases := []struct {
 		title        string
 		recipient    string
 		testRuns     []executor.TestRunSummary
+		serverErr    string // Slack API error code to simulate (e.g. "not_in_channel")
 		expectedMsgs map[string][]string
 		expectedErr  error
 	}{
@@ -101,6 +116,26 @@ func TestNotify(t *testing.T) {
 			expectedMsgs: map[string][]string{},
 			expectedErr:  ErrNoMappingForCodeowner,
 		},
+		{
+			title:     "bot not in channel returns posting error",
+			recipient: "codeowner-team",
+			testRuns: []executor.TestRunSummary{
+				{TestFolder: "test-suite", TestFile: "failed.js", Status: executor.TestFailed},
+			},
+			serverErr:    "not_in_channel",
+			expectedMsgs: map[string][]string{},
+			expectedErr:  ErrPostingMessage,
+		},
+		{
+			title:     "channel not found returns posting error",
+			recipient: "codeowner-team",
+			testRuns: []executor.TestRunSummary{
+				{TestFolder: "test-suite", TestFile: "failed.js", Status: executor.TestFailed},
+			},
+			serverErr:    "channel_not_found",
+			expectedMsgs: map[string][]string{},
+			expectedErr:  ErrPostingMessage,
+		},
 	}
 
 	mapping := CodeownersMapping{
@@ -111,7 +146,7 @@ func TestNotify(t *testing.T) {
 		t.Run(tc.title, func(t *testing.T) {
 			t.Parallel()
 
-			mock := newMockServer()
+			mock := newMockServerWithError(tc.serverErr)
 
 			handler := http.NewServeMux()
 			handler.HandleFunc("/chat.postMessage", mock.HandleChatPostMessage)

--- a/pkg/validate/code_owners.go
+++ b/pkg/validate/code_owners.go
@@ -39,8 +39,7 @@ func isMember(client *slack.Client, channelID string) ChannelStatus {
 	})
 
 	channelStatus := ChannelStatus{
-		ID:   channelID,
-		Name: channel.Name,
+		ID: channelID,
 	}
 
 	if err != nil {
@@ -53,9 +52,13 @@ func isMember(client *slack.Client, channelID string) ChannelStatus {
 			default:
 				channelStatus.Err = fmt.Errorf("error accessing channel: %s", slackErr.Err)
 			}
+		} else {
+			channelStatus.Err = err
 		}
-		channelStatus.Err = err
+		return channelStatus
 	}
+
+	channelStatus.Name = channel.Name
 
 	// Check if bot is a member
 	if !channel.IsMember {


### PR DESCRIPTION
Closes #562

## Summary

- **Tests**: Added `bot_not_in_channel_returns_posting_error` and `channel_not_found_returns_posting_error` test cases to `slack_notifier_test.go`, confirming bench returns `ErrPostingMessage` (→ exit code 2) rather than silently swallowing Slack API errors. Resolves the `// TODO: test errors from slack server` comment.
- **Bug fix**: `isMember()` in `pkg/validate/code_owners.go` had three issues:
  1. `channel.Name` and `channel.IsMember` were accessed before checking for a nil `channel` (returned when `GetConversationInfo` errors) — potential nil pointer panic
  2. `channelStatus.Err = err` on the line after the switch block unconditionally overwrote the human-readable error messages set inside the switch cases, making them dead code

## Investigation findings

The notification path (`bench test`) does **not** silently fail for issue #562. The error chain is intact: `PostMessage` error → `ErrPostingMessage` → collected by `notification_reporter` → `ChainReporter` → `cmd/test` returns error → `bench.go` logs + `os.Exit(2)`. The `notification_reporter_test.go` already has a generic `"error sending notification"` case, but there was no layer-specific test at the `slack_notifier` level.

## Test plan

- [x] `go test ./pkg/notifier/...` — new test cases pass
- [x] `go test ./...` — full suite green