### PR TITLE
Fix libsonnet generator: use std.escapeStringBash for run-dashboard URL

### DIFF
--- a/generators/libsonnet/README.md
+++ b/generators/libsonnet/README.md
@@ -179,8 +179,7 @@ The workflow ensures:
 
 ### Special Cases
 - **Required flags**: `grafana-url`, `suite-path` - Generate `error` defaults
-- **Escaped strings**: `pw-execute`, `pw-prepare` - Use `std.escapeStringBash`  
-- **URL escaping**: `run-dashboard` - Use custom `escapeString` function
+- **Escaped strings**: `pw-execute`, `pw-prepare`, `run-dashboard` - Use `std.escapeStringBash`
 - **Test environment**: `test-env` - Special array-to-comma-separated handling
 
 ### Deprecated Flags

--- a/generators/libsonnet/main.go
+++ b/generators/libsonnet/main.go
@@ -42,6 +42,7 @@ type TemplateData struct {
 	BaseImageURL       string
 	PlaywrightImageURL string
 	URLParamName       string // grafanaURL for v0.6.11, serviceURL for v1.0.0+
+	URLFlagName        string // --grafana-url for v0.6.11, --service-url for v1.0.0+
 }
 
 type VersionsTemplateData struct {
@@ -189,8 +190,10 @@ func generateMain() {
 
 	// Determine URL parameter name based on version
 	urlParamName := "serviceURL"
+	urlFlagName := "--service-url"
 	if targetVersion == "v0.6.11" {
 		urlParamName = "grafanaURL"
+		urlFlagName = "--grafana-url"
 	}
 
 	// Generate template data
@@ -201,6 +204,7 @@ func generateMain() {
 		BaseImageURL:       baseImageURL,
 		PlaywrightImageURL: playwrightImageURL,
 		URLParamName:       urlParamName,
+		URLFlagName:        urlFlagName,
 	}
 
 	// Load templates from files
@@ -674,7 +678,7 @@ func generateOptionalScriptFlag(flag FlagInfo) string {
 		return fmt.Sprintf("+ (if bench_options.%s then ['--%s'] else [])", camelCase, flag.Name)
 	case "string":
 		// Skip required strings - they're handled in the base array
-		if isRequiredStringFlag(flag.Name) {
+		if isRequiredStringFlag(flag.Name) || isBaseArrayFlag(flag.Name) {
 			return ""
 		}
 		// Handle special string escaping cases
@@ -682,7 +686,7 @@ func generateOptionalScriptFlag(flag FlagInfo) string {
 			return fmt.Sprintf("+ (if bench_options.%s != '' then ['--%s', std.escapeStringBash(bench_options.%s)] else [])", camelCase, flag.Name, camelCase)
 		}
 		if flag.Name == "run-dashboard" {
-			return fmt.Sprintf("+ (if bench_options.%s != '' then ['--%s', escapeString(bench_options.%s)] else [])", camelCase, flag.Name, camelCase)
+			return fmt.Sprintf("+ (if bench_options.%s != '' then ['--%s', std.escapeStringBash(bench_options.%s)] else [])", camelCase, flag.Name, camelCase)
 		}
 		return fmt.Sprintf("+ (if bench_options.%s != '' then ['--%s', bench_options.%s] else [])", camelCase, flag.Name, camelCase)
 	case "stringArray", "stringSlice":
@@ -795,6 +799,12 @@ func isRequiredStringFlag(flagName string) bool {
 		"suite-path":  true,
 	}
 	return requiredFlags[flagName]
+}
+
+// isBaseArrayFlag returns true for flags that are hardcoded in the base script
+// array and must not also be emitted as optional concatenations.
+func isBaseArrayFlag(flagName string) bool {
+	return flagName == "report-output"
 }
 
 func cleanUsage(usage string) string {

--- a/generators/libsonnet/tmpl/main.libsonnet.tmpl
+++ b/generators/libsonnet/tmpl/main.libsonnet.tmpl
@@ -13,14 +13,6 @@ local benchImage = '{{.BaseImageURL}}';
 local benchPlaywrightImage = '{{.PlaywrightImageURL}}';
 
 {
-  // URL escaping utility function (copied from jsonnet-libs/xtd for dependency-free operation)
-  local escapeString(str, excludedChars=[]) = (
-    local allowedChars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
-    local utf8(char) = std.foldl(function(a, b) a + '%%%02X' % b, std.encodeUTF8(char), '');
-    local escapeChar(char) = if std.member(excludedChars, char) || std.member(allowedChars, char) then char else utf8(char);
-    std.join('', std.map(escapeChar, std.stringChars(str)))
-  ),
-  
   // Suite template with version-specific defaults and documentation
   // Users can extend this template: local mySuite = benchFunctions.Suite + { suitePath: 'my/tests' };
   Suite:: {

--- a/generators/libsonnet/tmpl/main_test.jsonnet.tmpl
+++ b/generators/libsonnet/tmpl/main_test.jsonnet.tmpl
@@ -67,7 +67,7 @@ local tests = {
     // Check that required elements are present
     std.member(script, 'grafana-bench') &&
     std.member(script, 'test') &&
-    std.member(script, '--grafana-url') &&
+    std.member(script, '{{.URLFlagName}}') &&
     std.member(script, 'http://grafana:3000') &&
     std.member(script, '--suite-path') &&
     std.member(script, 'CI/k6') &&
@@ -94,9 +94,10 @@ local tests = {
     local options = benchFunctions.mapOptions(complexSuite);
     local script = benchFunctions.buildScript('http://grafana:3000', options);
     
-    // Check that test-env flag is properly formatted
+    // Check that test-env flags are passed as separate entries
     std.member(script, '--test-env') &&
-    std.member(script, 'VAR1="$"VAR1,VAR2="$"VAR2')
+    std.member(script, 'VAR1=value1') &&
+    std.member(script, 'VAR2=value2')
   ),
 
   // Test 7: Script generation excludes noFail when false

--- a/generators/utils/git.go
+++ b/generators/utils/git.go
@@ -64,8 +64,15 @@ func resolveMainRepoPath(path string) (string, error) {
 			if !filepath.IsAbs(commondir) {
 				commondir = filepath.Join(gitdir, commondir)
 			}
-			// commondir is the main .git directory; its parent is the repo root.
-			return filepath.Dir(filepath.Clean(commondir)), nil
+			// In a normal repo, commondir is the .git directory and its parent
+			// is the repo root. In a bare repo, commondir IS the repo root
+			// (there is no separate working tree .git subdir), so return it
+			// directly.
+			cleanCommondir := filepath.Clean(commondir)
+			if filepath.Base(cleanCommondir) == ".git" {
+				return filepath.Dir(cleanCommondir), nil
+			}
+			return cleanCommondir, nil
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
@@ -87,10 +94,7 @@ func GetLatestBenchTag(repoPath string) (string, error) {
 	}
 
 	// Open the repository
-	repo, err := git.PlainOpenWithOptions(
-		mainRepoPath,
-		&git.PlainOpenOptions{DetectDotGit: true},
-	)
+	repo, err := git.PlainOpen(mainRepoPath)
 	if err != nil {
 		return "", err
 	}
@@ -170,10 +174,7 @@ func GetShortCommitSHA(repoPath string) (string, error) {
 		mainRepoPath = repoPath
 	}
 
-	repo, err := git.PlainOpenWithOptions(
-		mainRepoPath,
-		&git.PlainOpenOptions{DetectDotGit: true},
-	)
+	repo, err := git.PlainOpen(mainRepoPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to open git repository: %w", err)
 	}
@@ -198,10 +199,7 @@ func GetLatestCommitForFile(repoPath string, filePath string) (string, error) {
 		mainRepoPath = repoPath
 	}
 
-	repo, err := git.PlainOpenWithOptions(
-		mainRepoPath,
-		&git.PlainOpenOptions{DetectDotGit: true},
-	)
+	repo, err := git.PlainOpen(mainRepoPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to open git repository: %w", err)
 	}
@@ -258,10 +256,7 @@ func GetLatestCommitForFileOnMain(repoPath string, filePath string) (string, err
 		mainRepoPath = repoPath
 	}
 
-	repo, err := git.PlainOpenWithOptions(
-		mainRepoPath,
-		&git.PlainOpenOptions{DetectDotGit: true},
-	)
+	repo, err := git.PlainOpen(mainRepoPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to open git repository: %w", err)
 	}


### PR DESCRIPTION
## Summary

- **Fixes #872**: Replace custom `escapeString()` (URL percent-encoding) with `std.escapeStringBash()` for `--run-dashboard`, consistent with how `pw-execute` and `pw-prepare` are already handled. The old encoding corrupted URLs by encoding `://`, `.`, `?`, `&`, `=`, etc., breaking Slack notification links.
- Remove now-unused local `escapeString()` function from `main.libsonnet.tmpl`
- Fix duplicate `--report-output` in generated scripts: introduce `isBaseArrayFlag()` to skip flags already hardcoded in the base array
- Fix test template: parameterize URL flag name per version (`--service-url` vs `--grafana-url`) and correct `testEnvironmentVariables` to match actual `flattenArrays` output (separate `--test-env` flags per entry) instead of the stale comma-joined format
- Fix git utils bare repo support in `resolveMainRepoPath()`: return the bare repo directory directly instead of its parent; switch from `PlainOpenWithOptions(DetectDotGit:true)` (incompatible with bare repos) to `PlainOpen`

## Test plan

- [x] `go test ./generators/libsonnet/... ./generators/utils/...` passes
- [x] `make libsonnet` generates successfully and all 9 jsonnet tests pass (`allTestsPassed: true`)