### PR TITLE
fix: quote workflow name to avoid YAML colon parsing error

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -1,4 +1,4 @@
-name: release: update docs
+name: "release: update docs"
 
 on:
   workflow_call:
@@ -51,8 +51,8 @@ jobs:
             fi
             VERSION="$LATEST_TAG"
           else
-            echo "Unsupported event: $EVENT_NAME"
-            exit 1
+            echo "Skipping: triggered by $EVENT_NAME (expected workflow_call or workflow_dispatch)"
+            exit 0
           fi
           
           AUTHOR="$ACTOR"


### PR DESCRIPTION
## Problem

The `release-docs.yml` workflow had an unquoted colon in its `name:` field:

```yaml
name: release: update docs
```

In YAML, `release: update docs` after the first colon is parsed as a nested mapping rather than a plain string, which corrupted the `on:` triggers. GitHub's parser couldn't read the triggers correctly, causing two cascading failures:

1. **`release-docs.yml` ran on every push** — with broken trigger parsing, GitHub defaulted to treating it as a push-triggered workflow, firing it on every branch push (including all Renovate PRs)
2. **`ci.yml` failed instantly with 0 jobs** — GitHub validates referenced workflows at parse time; since `ci.yml` calls `release-docs.yml` via `uses:`, the YAML error in `release-docs.yml` caused the entire `ci.yml` run to be rejected before any jobs started

## Fix

- Quote the name: `name: "release: update docs"`
- Change the `else` branch to `exit 0` instead of `exit 1` so unexpected triggers don't cause a noisy failure