### PR TITLE
fix(gotest): return zero duration when no tests are executed

### DIFF
--- a/pkg/parser/gotest/parser.go
+++ b/pkg/parser/gotest/parser.go
@@ -79,7 +79,9 @@ func ParseJsonOutput(report io.Reader) (executor.SuiteRunSummary, error) {
 		summary.TestRuns = append(summary.TestRuns, *test)
 	}
 
-	summary.TotalDuration += endTime.Sub(summary.StartTime)
+	if !endTime.IsZero() {
+		summary.TotalDuration += endTime.Sub(summary.StartTime)
+	}
 	summary.TestsExecuted = int32(len(summary.TestRuns))
 
 	return summary, nil

--- a/pkg/parser/gotest/parser_test.go
+++ b/pkg/parser/gotest/parser_test.go
@@ -91,6 +91,14 @@ func TestParseJsonOutput(t *testing.T) {
 			testdata:  "./testdata/output_invalid.json",
 			expectErr: ErrInvalidFormat,
 		},
+		{
+			name:     "empty test suite returns zero duration",
+			testdata: "./testdata/output_no_tests.json",
+			expect: executor.SuiteRunSummary{
+				TestsExecuted: 0,
+				TotalDuration: 0,
+			},
+		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/parser/gotest/testdata/output_no_tests.json
+++ b/pkg/parser/gotest/testdata/output_no_tests.json
@@ -1,0 +1,2 @@
+{"Time":"2025-06-04T10:09:37.954333835+02:00","Action":"start","Package":"github.com/grafana/grafana-bench/pkg/executor/gotest/tests"}
+{"Time":"2025-06-04T10:09:38.004333835+02:00","Action":"pass","Package":"github.com/grafana/grafana-bench/pkg/executor/gotest/tests","Elapsed":0.05}


### PR DESCRIPTION
## Summary

- Fixes a bug where running a Go test suite that executes no tests reports a negative duration (`-9223372036.85 sec`)
- Root cause: `endTime` was initialized to `time.Time{}` (Go zero time ≈ year 1 CE); when no tests ran, `endTime.Sub(startTime)` computed `year_1 - now` ≈ `math.MinInt64` nanoseconds
- Fix: guard the duration calculation with `!endTime.IsZero()` so an empty suite reports `0s`
- Added a test case and testdata file to cover this scenario

Fixes #654

## Test plan

- [ ] `go test ./pkg/parser/gotest/...` passes with new `empty test suite returns zero duration` test case
- [ ] All existing tests continue to pass (`go test ./...`)