### PR TITLE
fix(ci): use go-version-file instead of loose go-version range

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.x'
+          go-version-file: go.mod
           cache: false
 
       - name: Install


### PR DESCRIPTION
## Summary
- Fixes `go install` failure in the validate job caused by `GOTOOLCHAIN=local` mismatch
- Replaces `go-version: '>=1.21.x'` with `go-version-file: go.mod` so the job uses the exact toolchain declared in `go.mod`, consistent with all other jobs in the workflow

## Root cause
The validate job used a loose `>=1.21.x` version range, which could resolve to a Go version (e.g. 1.25.7) that doesn't satisfy the `toolchain` directive in `go.mod` (e.g. `go1.25.8`). With `GOTOOLCHAIN=local`, Go refuses to run rather than auto-downloading the required toolchain.