### PR TITLE
chore(ci): use GitHub App token broker in release-docs workflow

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -7,9 +7,6 @@ on:
 jobs:
   update-docs:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -65,12 +62,18 @@ jobs:
           echo "author=${AUTHOR}" >> $GITHUB_OUTPUT
           echo "Using version: ${VERSION}"
 
+      - name: Get GitHub App token
+        id: get-github-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
+        with:
+          github_app: grafana-pr-automation
+
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           base: main
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.get-github-app-token.outputs.token }}
           commit-message: "docs: update documentation and libsonnet for ${{ steps.get-info.outputs.version }}"
           title: "📚 Update documentation and libsonnet for ${{ steps.get-info.outputs.version }}"
           body: |
@@ -102,7 +105,7 @@ jobs:
       - name: Auto-merge PR
         if: steps.create-pr.outputs.pull-request-number
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
         run: |
           echo "Auto-merging PR #$PR_NUMBER"


### PR DESCRIPTION
## Summary

- Adds a `Get GitHub App token` step using `grafana/shared-workflows/actions/create-github-app-token` with the `grafana-pr-automation` app
- Replaces both `secrets.GITHUB_TOKEN` usages (`peter-evans/create-pull-request` token and `gh pr merge` GH_TOKEN) with `steps.get-github-app-token.outputs.token`
- Removes the job-level `permissions: contents: write / pull-requests: write` block since those are now handled by the GitHub App