### PR TITLE
fix(libsonnet): make test assertions throw on failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,14 +56,14 @@ libsonnet: install-deps
 	@echo "🔧 Generating libsonnet for $(or $(TARGET_VERSION),experimental) (local versions only)..."
 	@go run ./generators/libsonnet generate --target-version "$(or $(TARGET_VERSION),experimental)" -o libsonnet >/dev/null 2>&1
 	@VERSION="$(or $(TARGET_VERSION),experimental)"; LABEL=$$([ "$$VERSION" = "experimental" ] && git rev-parse HEAD || echo "$$VERSION"); go run ./generators/libsonnet versions --target-version "$$VERSION" --versions-list local --latest-version-sha "$$LABEL" -o libsonnet >/dev/null 2>&1
-	@cd libsonnet && jsonnet "$(or $(TARGET_VERSION),experimental)/main_test.jsonnet" | grep -q '"allTestsPassed": true' && echo "✅ All tests passed" || echo "⚠️ Tests skipped"
+	@cd libsonnet && jsonnet "$(or $(TARGET_VERSION),experimental)/main_test.jsonnet" && echo "✅ All tests passed"
 
 # Generate libsonnet library with remote version fetching
 libsonnet-fetch: install-deps
 	@echo "🔧 Generating libsonnet for $(or $(TARGET_VERSION),experimental) (fetching remote versions)..."
 	@go run ./generators/libsonnet generate --target-version "$(or $(TARGET_VERSION),experimental)" -o libsonnet >/dev/null 2>&1
 	@VERSION="$(or $(TARGET_VERSION),experimental)"; LABEL=$$([ "$$VERSION" = "experimental" ] && git rev-parse HEAD || echo "$$VERSION"); go run ./generators/libsonnet versions --target-version "$$VERSION" --versions-list fetch --latest-version-sha "$$LABEL" -o libsonnet >/dev/null 2>&1
-	@cd libsonnet && jsonnet "$(or $(TARGET_VERSION),experimental)/main_test.jsonnet" | grep -q '"allTestsPassed": true' && echo "✅ All tests passed" || echo "⚠️ Tests skipped"
+	@cd libsonnet && jsonnet "$(or $(TARGET_VERSION),experimental)/main_test.jsonnet" && echo "✅ All tests passed"
 
 
 # Install development dependencies

--- a/generators/libsonnet/tmpl/main_test.jsonnet.tmpl
+++ b/generators/libsonnet/tmpl/main_test.jsonnet.tmpl
@@ -63,50 +63,50 @@ local tests = {
   testBasicScriptGeneration: (
     local options = benchFunctions.mapOptions(basicSuite);
     local script = benchFunctions.buildScript('http://grafana:3000', options);
-    
+
     // Check that required elements are present
-    std.member(script, 'grafana-bench') &&
-    std.member(script, 'test') &&
-    std.member(script, '{{.URLFlagName}}') &&
-    std.member(script, 'http://grafana:3000') &&
-    std.member(script, '--suite-path') &&
-    std.member(script, 'CI/k6') &&
-    std.member(script, '--test-runner') &&
-    std.member(script, 'k6')
+    std.assertEqual(std.member(script, 'grafana-bench'), true) &&
+    std.assertEqual(std.member(script, 'test'), true) &&
+    std.assertEqual(std.member(script, '{{.URLFlagName}}'), true) &&
+    std.assertEqual(std.member(script, 'http://grafana:3000'), true) &&
+    std.assertEqual(std.member(script, '--suite-path'), true) &&
+    std.assertEqual(std.member(script, 'CI/k6'), true) &&
+    std.assertEqual(std.member(script, '--test-runner'), true) &&
+    std.assertEqual(std.member(script, 'k6'), true)
   ),
 
   // Test 5: Script generation with optional flags
   testScriptWithOptionalFlags: (
     local options = benchFunctions.mapOptions(complexSuite);
     local script = benchFunctions.buildScript('http://grafana:3000', options);
-    
+
     // Check that optional flags are included when enabled
-    std.member(script, '--prometheus-metrics') &&
-    std.member(script, '--prometheus-url') &&
-    std.member(script, 'http://prometheus:9090') &&
-    std.member(script, '--slack-notifications') &&
-    std.member(script, '--slack-token') &&
-    std.member(script, 'test-token')
+    std.assertEqual(std.member(script, '--prometheus-metrics'), true) &&
+    std.assertEqual(std.member(script, '--prometheus-url'), true) &&
+    std.assertEqual(std.member(script, 'http://prometheus:9090'), true) &&
+    std.assertEqual(std.member(script, '--slack-notifications'), true) &&
+    std.assertEqual(std.member(script, '--slack-token'), true) &&
+    std.assertEqual(std.member(script, 'test-token'), true)
   ),
 
   // Test 6: Environment variable handling
   testEnvironmentVariables: (
     local options = benchFunctions.mapOptions(complexSuite);
     local script = benchFunctions.buildScript('http://grafana:3000', options);
-    
+
     // Check that test-env flags are passed as separate entries
-    std.member(script, '--test-env') &&
-    std.member(script, 'VAR1=value1') &&
-    std.member(script, 'VAR2=value2')
+    std.assertEqual(std.member(script, '--test-env'), true) &&
+    std.assertEqual(std.member(script, 'VAR1=value1'), true) &&
+    std.assertEqual(std.member(script, 'VAR2=value2'), true)
   ),
 
   // Test 7: Script generation excludes noFail when false
   testScriptNoFailFalse: (
     local options = benchFunctions.mapOptions(basicSuite);
     local script = benchFunctions.buildScript('http://grafana:3000', options);
-    
+
     // Check that || true is NOT included when noFail is false
-    !std.member(script, '|| true')
+    std.assertEqual(std.member(script, '|| true'), false)
   ),
 
   // Test 8: Script generation includes noFail when true
@@ -114,9 +114,9 @@ local tests = {
     local suiteWithNoFail = basicSuite + { options: { noFail: true } };
     local options = benchFunctions.mapOptions(suiteWithNoFail);
     local script = benchFunctions.buildScript('http://grafana:3000', options);
-    
+
     // Check that || true IS included when noFail is true
-    std.member(script, '|| true')
+    std.assertEqual(std.member(script, '|| true'), true)
   ),
 };
 


### PR DESCRIPTION
## Problem

Generated `*_test.jsonnet` files used `std.member()` for array-membership checks, which returns `false` silently on mismatch. This meant:

- `allTestsPassed: false` could appear in test output while jsonnet still exited 0
- `make libsonnet` (and any downstream `make test-jsonnet`) would pass even with broken assertions
- Several versions in deployment_tools had stale/wrong assertions that went undetected for weeks (e.g. v1.0.0/v1.0.1 checking `--grafana-url` after the flag was renamed to `--service-url`)

Additionally, the `make libsonnet` / `make libsonnet-fetch` targets used `|| echo "⚠️ Tests skipped"` as a fallback, which swallowed both jsonnet runtime errors and `allTestsPassed: false`, treating all failures as skips.

## Fix

- Wrap all `std.member(script, x)` calls in `std.assertEqual(std.member(script, x), true/false)` in `main_test.jsonnet.tmpl` so assertion failures throw a jsonnet runtime error (non-zero exit)
- Remove the `|| echo "⚠️ Tests skipped"` fallback in `Makefile` so `make libsonnet` fails properly when jsonnet exits non-zero

## Test plan

- `make libsonnet` passes with correct template
- Introducing a wrong flag in the template (`--wrong-flag` instead of `--service-url`) causes `RUNTIME ERROR: Assertion failed. false != true` and `make libsonnet` exits non-zero
- `go test ./generators/libsonnet/...` passes