### PR TITLE
fix(ci): add id-token permission for update-docs job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,4 +440,5 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     uses: ./.github/workflows/release-docs.yml


### PR DESCRIPTION
## Summary
- Adds missing `id-token: write` permission to the `update-docs` job in CI
- The `create-github-app-token` action uses Vault via OIDC, which requires this permission to obtain `ACTIONS_ID_TOKEN_REQUEST_URL`

## Test plan
- After merging, run `gh workflow run 245422065 --repo grafana/grafana-bench --ref main` to verify the fix