### PR TITLE
Update migration documentation for metrics file option

### DIFF
--- a/docs/migration_v1.md
+++ b/docs/migration_v1.md
@@ -59,6 +59,7 @@ grafana-bench test \
 | `--test-executor` | `--test-runner` | Yes |
 | `--pw-prepare-cmd` | `--pw-prepare` | No |
 | `--pw-execute-cmd` | `--pw-execute` | No |
+| `--metrics-file` | `--run-metrics-file` | No |
 
 *Required unless using `--fetch-grafana-version`
 


### PR DESCRIPTION
Added `--metrics-file` option and its replacement `--run-metrics-file` to the migration documentation.
