### PR TITLE
k6 retry support

### DIFF
--- a/docs/writing_k6_api_tests.md
+++ b/docs/writing_k6_api_tests.md
@@ -53,6 +53,35 @@ Tests error 0
 Tests suite passed
 ```
 
+## Retrying failed tests
+
+If a test can fail transiently — for example, because the service under test briefly returns 5xx during a deploy — you can ask bench to retry failed tests before giving up:
+
+```sh
+grafana-bench test \
+  --test-runner k6 \
+  --k6-retries 3 \
+  --k6-retry-delay 10s \
+  ... other flags ...
+```
+
+- `--k6-retries` — maximum number of retries after the initial run (default `0`, retries off).
+- `--k6-retry-delay` — wait between attempts (default `0`). Accepts any Go duration (`500ms`, `5s`, `1m`).
+
+Each retry re-runs the entire test file (including setup and teardown). JSON output for attempt 1 keeps the historical `/tmp/<name>.json` path; retry attempts write to `/tmp/<name>-attempt-N.json` so prior runs are preserved for postmortem.
+
+### Reporting
+
+Each test logs `attempts` and `maxAttempts` on its `msg=testRun` summary line. Status is reported as:
+
+- `passed` — passed on the first attempt.
+- `flaky` — failed at least once but passed within the retry budget. A `bench_test_run_flaky` metric is emitted.
+- `failed` — failed every attempt.
+
+The `totalDuration` for a retried test is the sum of wall-clock time across all attempts, so a test that keeps retrying shows an increasing duration.
+
+> **Note:** `bench analyze` treats tests reported as `flaky` as not-a-defect by design. Enabling retries reduces the number of defects the analyzer can confirm — only tests that fail every attempt will surface as confirmed defects.
+
 ## Introduction
 
 K6 tests are written in JavaScript and run in the Goja runtime. This is a small but important detail. While it looks like standard JavaScript, we don't have all of the capabilities of Node and K6 has added a few of its own.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -114,6 +114,8 @@ type K6Config struct {
 	CloudToken     string
 	CloudProjectId string
 	CloudOutput    bool
+	Retries        int
+	RetryDelay     time.Duration
 }
 
 func AddK6Flags(fs *pflag.FlagSet, config *K6Config) {
@@ -134,6 +136,18 @@ func AddK6Flags(fs *pflag.FlagSet, config *K6Config) {
 		"k6-cloud-output",
 		false,
 		"send output to GCK6. Requires setting the GCK6 project ID and access token.",
+	)
+	fs.IntVar(
+		&config.Retries,
+		"k6-retries",
+		0,
+		"number of retries for failed k6 tests. Retried tests that pass are reported as flaky",
+	)
+	fs.DurationVar(
+		&config.RetryDelay,
+		"k6-retry-delay",
+		0,
+		"delay between k6 test retries (e.g. 5s, 1m). Useful for letting the system under test recover between attempts",
 	)
 }
 
@@ -158,11 +172,12 @@ func AddPlaywrightFlags(fs *pflag.FlagSet, config *PWConfig) {
 	)
 }
 
-type GoTestConfig struct{
-	GoArgs   []string
-	TestArgs []string
-	Packages []string
-	Retries  int
+type GoTestConfig struct {
+	GoArgs     []string
+	TestArgs   []string
+	Packages   []string
+	Retries    int
+	RetryDelay time.Duration
 }
 
 func AddGoExecutorFlags(fs *pflag.FlagSet, config *GoTestConfig) {
@@ -177,6 +192,12 @@ func AddGoExecutorFlags(fs *pflag.FlagSet, config *GoTestConfig) {
 		"go-retries",
 		0,
 		"number of retries for failed tests. Retried tests that pass are reported as flaky",
+	)
+	fs.DurationVar(
+		&config.RetryDelay,
+		"go-retry-delay",
+		0,
+		"delay between go test retries (e.g. 5s, 1m). Useful for letting the system under test recover between attempts",
 	)
 	fs.StringArrayVar(
 		&config.TestArgs,
@@ -586,10 +607,11 @@ func (config BenchConfig) BuildTestExecutor(
 		executor = gotest.NewGoExecutor(
 			log,
 			gotest.GoExecutorOptions{
-				GoArgs:   config.Go.GoArgs,
-				Packages: config.Go.Packages,
-				TestArgs: config.Go.TestArgs,
-				Retries:  config.Go.Retries,
+				GoArgs:     config.Go.GoArgs,
+				Packages:   config.Go.Packages,
+				TestArgs:   config.Go.TestArgs,
+				Retries:    config.Go.Retries,
+				RetryDelay: config.Go.RetryDelay,
 			},
 		)
 	case "gobench":
@@ -613,6 +635,8 @@ func (config BenchConfig) BuildTestExecutor(
 				CloudOutput:    config.K6.CloudOutput,
 				CloudToken:     config.K6.CloudToken,
 				CloudProjectID: config.K6.CloudProjectId,
+				RetryFailed:    config.K6.Retries,
+				RetryDelay:     config.K6.RetryDelay,
 			},
 		)
 	case "playwright":

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -46,6 +46,11 @@ type TestRunSummary struct {
 	Iterations       string        `json:"iterations"`
 	TotalDuration    time.Duration `json:"totalDuration"`
 	ScenarioDuration time.Duration `json:"scenarioDuration"`
+	// Attempts is the number of times the test ran (initial run + retries).
+	// Always >= 1 for tests that executed.
+	Attempts int `json:"attempts"`
+	// MaxAttempts is the configured upper bound (1 + configured retries).
+	MaxAttempts int `json:"maxAttempts"`
 	// Attributes are provided by the test runner and not user configurable
 	Attributes map[string]string `json:"attributes"`
 }

--- a/pkg/executor/gotest/executor.go
+++ b/pkg/executor/gotest/executor.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 
 	"github.com/grafana/grafana-bench/pkg/executor"
 	"github.com/grafana/grafana-bench/pkg/metrics"
@@ -27,24 +28,28 @@ type GoExecutorOptions struct {
 	TestArgs []string
 	// retries for failed tests
 	Retries int
+	// RetryDelay between retries
+	RetryDelay time.Duration
 }
 
 // GoExecutor implements an TestExecutor for go tests
 type GoExecutor struct {
-	log      *slog.Logger
-	goArgs   []string
-	testArgs []string
-	packages []string
-	retries  int
+	log        *slog.Logger
+	goArgs     []string
+	testArgs   []string
+	packages   []string
+	retries    int
+	retryDelay time.Duration
 }
 
 func NewGoExecutor(log *slog.Logger, opts GoExecutorOptions) *GoExecutor {
 	return &GoExecutor{
-		log:      log,
-		goArgs:   opts.GoArgs,
-		testArgs: opts.TestArgs,
-		retries:  opts.Retries,
-		packages: opts.Packages,
+		log:        log,
+		goArgs:     opts.GoArgs,
+		testArgs:   opts.TestArgs,
+		retries:    opts.Retries,
+		retryDelay: opts.RetryDelay,
+		packages:   opts.Packages,
 	}
 }
 
@@ -72,6 +77,12 @@ func (e *GoExecutor) ExecTestSuite(
 	summary.SuiteName = suite.Name
 	summary.SuiteRevision = suite.Revision
 
+	maxAttempts := e.retries + 1
+	for i := range summary.TestRuns {
+		summary.TestRuns[i].Attempts = 1
+		summary.TestRuns[i].MaxAttempts = maxAttempts
+	}
+
 	if summary.TestsFailed > 0 && e.retries > 0 {
 		for i, t := range summary.TestRuns {
 			if t.Status != executor.TestFailed {
@@ -79,6 +90,14 @@ func (e *GoExecutor) ExecTestSuite(
 			}
 
 			for range e.retries {
+				if e.retryDelay > 0 {
+					select {
+					case <-ctx.Done():
+						return summary, nil
+					case <-time.After(e.retryDelay):
+					}
+				}
+
 				tr, err := retryTest(ctx, e.log, workDir, t.TestFolder, e.goArgs, e.testArgs, t.TestFile)
 				if err != nil {
 					return executor.SuiteRunSummary{}, fmt.Errorf("failed to run go test %w", err)
@@ -86,6 +105,7 @@ func (e *GoExecutor) ExecTestSuite(
 
 				// account for additional duration of retries
 				summary.TestRuns[i].TotalDuration += tr.TotalDuration
+				summary.TestRuns[i].Attempts++
 
 				// adjust suite's total duration to account for retries
 				if tr.StartTime.Add(tr.TotalDuration).After(summary.StartTime.Add(summary.TotalDuration)) {

--- a/pkg/executor/gotest/executor_test.go
+++ b/pkg/executor/gotest/executor_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/grafana/grafana-bench/pkg/executor"
 	"github.com/grafana/grafana-bench/pkg/metrics"
@@ -129,7 +130,7 @@ func TestFlakyTest(t *testing.T) {
 				TestsExecuted: 1,
 				TestsFailed:   1,
 				TestRuns: []executor.TestRunSummary{
-					{TestFile: "TestFlaky", Status: executor.TestFailed},
+					{TestFile: "TestFlaky", Status: executor.TestFailed, Attempts: 1, MaxAttempts: 1},
 				},
 			},
 		},
@@ -148,7 +149,36 @@ func TestFlakyTest(t *testing.T) {
 				TestsExecuted: 1,
 				TestsFlaky:    1,
 				TestRuns: []executor.TestRunSummary{
-					{TestFile: "TestFlaky", Status: executor.TestFlaky},
+					{TestFile: "TestFlaky", Status: executor.TestFlaky, Attempts: 2, MaxAttempts: 4},
+				},
+				Metrics: []metrics.Metric{
+					{
+						Name:  "bench_test_run_flaky",
+						Value: 1,
+						Labels: map[string]string{
+							"test_full_path": "github.com/grafana/grafana-bench/pkg/executor/gotest/flaky/TestFlaky",
+						},
+					},
+				},
+			},
+		},
+		{
+			title: "retry delay sleeps between attempts",
+			opts: GoExecutorOptions{
+				Packages:   []string{"./..."},
+				Retries:    1,
+				RetryDelay: 200 * time.Millisecond,
+			},
+			suite: executor.TestSuite{
+				Path: "flaky",
+			},
+			expectErr: nil,
+			expect: executor.SuiteRunSummary{
+				Status:        executor.SuiteFailed,
+				TestsExecuted: 1,
+				TestsFlaky:    1,
+				TestRuns: []executor.TestRunSummary{
+					{TestFile: "TestFlaky", Status: executor.TestFlaky, Attempts: 2, MaxAttempts: 2},
 				},
 				Metrics: []metrics.Metric{
 					{
@@ -181,9 +211,19 @@ func TestFlakyTest(t *testing.T) {
 
 			log := slog.New(slog.NewTextHandler(io.Discard, nil))
 			goExec := NewGoExecutor(log, opts)
+			start := time.Now()
 			summary, err := goExec.ExecTestSuite(context.TODO(), tc.suite, map[string]string{})
+			elapsed := time.Since(start)
 			if !errors.Is(err, tc.expectErr) {
 				t.Fatalf("expected %v got %v", tc.expectErr, err)
+			}
+
+			// wall-clock must cover at least retryDelay * (attempts - 1)
+			if opts.RetryDelay > 0 {
+				minSleep := opts.RetryDelay
+				if elapsed < minSleep {
+					t.Errorf("elapsed %v should be >= RetryDelay %v", elapsed, minSleep)
+				}
 			}
 
 			// we can't assert durations because are unpredictable
@@ -198,6 +238,8 @@ func TestFlakyTest(t *testing.T) {
 			for i, tr := range tc.expect.TestRuns {
 				assert.Equal(t, "test file", tr.TestFile, summary.TestRuns[i].TestFile)
 				assert.Equal(t, "test status", tr.Status, summary.TestRuns[i].Status)
+				assert.Equal(t, "test attempts", tr.Attempts, summary.TestRuns[i].Attempts)
+				assert.Equal(t, "test maxAttempts", tr.MaxAttempts, summary.TestRuns[i].MaxAttempts)
 			}
 
 			// assert metrics

--- a/pkg/executor/k6/k6_executor.go
+++ b/pkg/executor/k6/k6_executor.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-bench/pkg/executor"
+	"github.com/grafana/grafana-bench/pkg/metrics"
 	k6parser "github.com/grafana/grafana-bench/pkg/parser/k6"
 	"github.com/grafana/grafana-bench/pkg/utils"
 	"github.com/grafana/grafana-bench/pkg/utils/format"
@@ -46,6 +47,7 @@ type K6TestExecutor struct {
 
 type K6ExecutorOptions struct {
 	RetryFailed    int
+	RetryDelay     time.Duration
 	Verbose        bool
 	CloudOutput    bool
 	CloudToken     string
@@ -125,6 +127,8 @@ func (t *K6TestExecutor) ExecTestSuite(
 	suiteSummary.SuiteName = suite.Name
 	suiteSummary.SuiteRevision = suite.Revision
 
+	maxAttempts := t.RetryFailed + 1
+
 	// run the tests
 	for _, testFile := range tests {
 		scenarioName := getScenarioName(testFile)
@@ -132,19 +136,26 @@ func (t *K6TestExecutor) ExecTestSuite(
 
 		var (
 			testStartTime time.Time
-			retries       int
+			attempts      int
+			totalDuration time.Duration
 			k6Summary     K6TestRun
 		)
 
+	retryLoop:
 		for {
-			// reset the start time for each test retry
-			testStartTime = time.Now()
+			attempts++
 
-			// run command send output to cloud
+			// record start time on the first attempt so wall-clock duration
+			// covers the initial run plus any retries and retry delays.
+			if attempts == 1 {
+				testStartTime = time.Now()
+			}
+
 			k6Summary, err = t.execTest(
 				ctx,
 				testFile,
 				scenarioName,
+				attempts,
 				k6env,
 			)
 			if err != nil {
@@ -152,17 +163,28 @@ func (t *K6TestExecutor) ExecTestSuite(
 				// TODO: maybe we should break the iteration here, as test result may not be relevant
 			}
 
-			if k6Summary.Status != executor.TestFailed || retries == t.RetryFailed {
+			// accumulate duration across every attempt so repeated retries
+			// show up as an increasing TotalDuration.
+			totalDuration += k6Summary.Durations.TotalDuration
+
+			if k6Summary.Status != executor.TestFailed || attempts >= maxAttempts {
 				break
 			}
-			retries++
+
+			if t.RetryDelay > 0 {
+				select {
+				case <-ctx.Done():
+					break retryLoop
+				case <-time.After(t.RetryDelay):
+				}
+			}
 		}
 
-		if k6Summary.Status == executor.TestPassed && retries > 0 {
+		if k6Summary.Status == executor.TestPassed && attempts > 1 {
 			k6Summary.Status = executor.TestFlaky
 		}
 
-		scenariosDuration += k6Summary.Durations.TotalDuration
+		scenariosDuration += totalDuration
 
 		// get the path to the test relative to the TestSuiteBase if any
 		// we don't need to check for errors because how the test path is constructed
@@ -174,9 +196,11 @@ func (t *K6TestExecutor) ExecTestSuite(
 			TestFile:         path.Base(testFile),
 			StartTime:        testStartTime,
 			Status:           k6Summary.Status,
-			TotalDuration:    k6Summary.Durations.TotalDuration,
+			TotalDuration:    totalDuration,
 			ScenarioDuration: k6Summary.Durations.ScenarioDuration,
 			Iterations:       k6Summary.Iterations,
+			Attempts:         attempts,
+			MaxAttempts:      maxAttempts,
 			ExitMessage:      k6Summary.ExitMessage,
 			Attributes: map[string]string{
 				"cloudId":          k6Summary.CloudID,
@@ -192,6 +216,14 @@ func (t *K6TestExecutor) ExecTestSuite(
 			suiteSummary.TestsPassed += 1
 		case executor.TestFlaky:
 			suiteSummary.TestsFlaky += 1
+			suiteSummary.Metrics = append(suiteSummary.Metrics, metrics.Metric{
+				Name:  "bench_test_run_flaky",
+				Value: 1,
+				Labels: map[string]string{
+					"test_full_path": summary.TestFolder + "/" + summary.TestFile,
+				},
+				Timestamp: summary.StartTime.UnixMilli(),
+			})
 		case executor.TestFailed:
 			suiteSummary.TestsFailed += 1
 		case executor.TestError:
@@ -217,6 +249,7 @@ func (t *K6TestExecutor) execTest(
 	ctx context.Context,
 	testFile string,
 	scenarioName string,
+	attempt int,
 	env map[string]string,
 ) (K6TestRun, error) {
 	testFile, err := transpileTest(testFile)
@@ -224,7 +257,7 @@ func (t *K6TestExecutor) execTest(
 		return K6TestRun{}, err
 	}
 
-	jsonFile := getJsonOutputFilename(testFile)
+	jsonFile := getJsonOutputFilename(testFile, attempt)
 
 	// build the command with buffer
 	cmd, buf := t.prepareK6Command(
@@ -459,9 +492,16 @@ func (t *K6TestExecutor) getOutput(buf *bytes.Buffer, jsonFile string, scenarioN
 	}, err
 }
 
-// dashboard_create.js -> /tmp/dashboard_create.json
-func getJsonOutputFilename(filename string) string {
+// getJsonOutputFilename returns a deterministic path under /tmp for k6's JSON output.
+// Attempt 1 keeps the historical /tmp/<name>.json path; retries are written to
+// /tmp/<name>-attempt-N.json so earlier runs are preserved for postmortem.
+// dashboard_create.js -> /tmp/dashboard_create.json (attempt 1)
+// dashboard_create.js -> /tmp/dashboard_create-attempt-2.json (attempt 2)
+func getJsonOutputFilename(filename string, attempt int) string {
 	jsonName := filepath.Base(filename)
 	jsonName = strings.TrimSuffix(jsonName, filepath.Ext(jsonName))
+	if attempt > 1 {
+		jsonName = fmt.Sprintf("%s-attempt-%d", jsonName, attempt)
+	}
 	return path.Join("/tmp", jsonName+".json")
 }

--- a/pkg/executor/k6/k6_executor_test.go
+++ b/pkg/executor/k6/k6_executor_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/grafana/grafana-bench/pkg/executor"
 	"github.com/grafana/grafana-bench/pkg/utils/test/assert"
@@ -17,6 +18,14 @@ type k6TestExecutorOption func(*K6TestExecutor) error
 func WithRetries(retries int) k6TestExecutorOption {
 	return func(t *K6TestExecutor) error {
 		t.RetryFailed = retries
+		return nil
+	}
+}
+
+// configure TestRunner with retry delay
+func WithRetryDelay(d time.Duration) k6TestExecutorOption {
+	return func(t *K6TestExecutor) error {
+		t.RetryDelay = d
 		return nil
 	}
 }
@@ -75,7 +84,7 @@ func TestK6Executor(t *testing.T) {
 				TestsExecuted: 1,
 				TestsPassed:   1,
 				TestRuns: []executor.TestRunSummary{
-					{TestFile: "pass.js", Status: executor.TestPassed},
+					{TestFile: "pass.js", Status: executor.TestPassed, Attempts: 1, MaxAttempts: 1},
 				},
 			},
 		},
@@ -86,7 +95,7 @@ func TestK6Executor(t *testing.T) {
 				TestsExecuted: 1,
 				TestsFailed:   1,
 				TestRuns: []executor.TestRunSummary{
-					{TestFile: "fail.js", Status: executor.TestFailed},
+					{TestFile: "fail.js", Status: executor.TestFailed, Attempts: 1, MaxAttempts: 1},
 				},
 			},
 		},
@@ -100,7 +109,22 @@ func TestK6Executor(t *testing.T) {
 				TestsExecuted: 1,
 				TestsFailed:   1,
 				TestRuns: []executor.TestRunSummary{
-					{TestFile: "fail.js", Status: executor.TestFailed},
+					{TestFile: "fail.js", Status: executor.TestFailed, Attempts: 4, MaxAttempts: 4},
+				},
+			},
+		},
+		{
+			testCase:  "retry delay sleeps between attempts",
+			testSuite: "k6tests/fail.js",
+			k6options: []k6TestExecutorOption{
+				WithRetries(1),
+				WithRetryDelay(500 * time.Millisecond),
+			},
+			expect: &executor.SuiteRunSummary{
+				TestsExecuted: 1,
+				TestsFailed:   1,
+				TestRuns: []executor.TestRunSummary{
+					{TestFile: "fail.js", Status: executor.TestFailed, Attempts: 2, MaxAttempts: 2},
 				},
 			},
 		},
@@ -111,7 +135,7 @@ func TestK6Executor(t *testing.T) {
 				TestsExecuted: 1,
 				TestsError:    1,
 				TestRuns: []executor.TestRunSummary{
-					{TestFile: "abort.js", Status: executor.TestError},
+					{TestFile: "abort.js", Status: executor.TestError, Attempts: 1, MaxAttempts: 1},
 				},
 			},
 		},
@@ -129,9 +153,9 @@ func TestK6Executor(t *testing.T) {
 				TestsFailed:   1,
 				TestsPassed:   1,
 				TestRuns: []executor.TestRunSummary{
-					{TestFile: "abort.js", Status: executor.TestError},
-					{TestFile: "fail.js", Status: executor.TestFailed},
-					{TestFile: "pass.js", Status: executor.TestPassed},
+					{TestFile: "abort.js", Status: executor.TestError, Attempts: 1, MaxAttempts: 1},
+					{TestFile: "fail.js", Status: executor.TestFailed, Attempts: 1, MaxAttempts: 1},
+					{TestFile: "pass.js", Status: executor.TestPassed, Attempts: 1, MaxAttempts: 1},
 				},
 			},
 		},
@@ -146,7 +170,7 @@ func TestK6Executor(t *testing.T) {
 				TestsExecuted: 1,
 				TestsError:   1,
 				TestRuns: []executor.TestRunSummary{
-					{TestFile: "pass.js", Status: executor.TestError},
+					{TestFile: "pass.js", Status: executor.TestError, Attempts: 1, MaxAttempts: 1},
 				},
 			},
 		},
@@ -179,7 +203,9 @@ func TestK6Executor(t *testing.T) {
 				t.Fatalf("failed to setup the k6 executor %v", err)
 			}
 
+			start := time.Now()
 			summary, err := k6Executor.ExecTestSuite(context.TODO(), suite, map[string]string{})
+			elapsed := time.Since(start)
 
 			if !errors.Is(err, tc.expectErr) {
 				t.Fatalf("expected '%v' got: '%v'", tc.expectErr, err)
@@ -187,6 +213,14 @@ func TestK6Executor(t *testing.T) {
 
 			if tc.expectErr != nil {
 				return
+			}
+
+			// when retry delay is set, wall-clock should be >= delay * (retries)
+			if k6Executor.RetryDelay > 0 {
+				minSleep := k6Executor.RetryDelay
+				if elapsed < minSleep {
+					t.Errorf("elapsed %v should be >= RetryDelay %v", elapsed, minSleep)
+				}
 			}
 
 			// we can't assert durations because are unpredictable
@@ -198,7 +232,33 @@ func TestK6Executor(t *testing.T) {
 			for i, tr := range tc.expect.TestRuns {
 				assert.Equal(t, "test file", tr.TestFile, summary.TestRuns[i].TestFile)
 				assert.Equal(t, "test status", tr.Status, summary.TestRuns[i].Status)
+				assert.Equal(t, "test attempts", tr.Attempts, summary.TestRuns[i].Attempts)
+				assert.Equal(t, "test maxAttempts", tr.MaxAttempts, summary.TestRuns[i].MaxAttempts)
 			}
 		})
+	}
+}
+
+// TestGetJsonOutputFilename verifies retries target a separate JSON file so
+// prior attempts are preserved for postmortem.
+func TestGetJsonOutputFilename(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		filename string
+		attempt  int
+		want     string
+	}{
+		{"dashboard_create.js", 1, "/tmp/dashboard_create.json"},
+		{"dashboard_create.js", 2, "/tmp/dashboard_create-attempt-2.json"},
+		{"dashboard_create.js", 3, "/tmp/dashboard_create-attempt-3.json"},
+		{"/some/abs/path/foo.js", 1, "/tmp/foo.json"},
+		{"/some/abs/path/foo.js", 4, "/tmp/foo-attempt-4.json"},
+	}
+	for _, c := range cases {
+		got := getJsonOutputFilename(c.filename, c.attempt)
+		if got != c.want {
+			t.Errorf("getJsonOutputFilename(%q, %d) = %q, want %q", c.filename, c.attempt, got, c.want)
+		}
 	}
 }

--- a/pkg/reporter/log_reporter.go
+++ b/pkg/reporter/log_reporter.go
@@ -76,6 +76,8 @@ func (r *LogReporter) Report(
 			"scenarioDuration", format.PrettyMS(testRun.ScenarioDuration),
 			"totalDuration", format.PrettyMS(testRun.TotalDuration),
 			"status", testRun.Status,
+			"attempts", testRun.Attempts,
+			"maxAttempts", testRun.MaxAttempts,
 			"exitMessage", testRun.ExitMessage,
 			"order", strconv.Itoa(order),
 		}


### PR DESCRIPTION
## Summary

Adds retry support to the **k6** runner and brings retry reporting to parity across runners. k6 already had a basic retry loop and `flaky` status; this PR adds a configurable retry **delay**, per-attempt tracking, the per-test flaky metric (matching gotest), a new low-cardinality aggregate retries metric, and CLI flags — plus the matching `--go-retry-delay` for the go runner.

k6 does not support retries natively. We need them to ride out flaky tests in the release pipeline against dev/prod, and we want the **same functionality and metric names across runners**.

## Changes

**Flags** (`pkg/config/config.go`)
- `--k6-retries` — number of retries after the initial run (default `0`, off). Tests that pass on a retry are reported as `flaky`.
- `--k6-retry-delay` — wait between attempts (e.g. `5s`, `1m`), to let the system under test recover.
- `--go-retry-delay` — same delay control for the go runner (which already had `--go-retries`).

**Executors** (`pkg/executor/k6`, `pkg/executor/gotest`)
- ctx-aware retry delay between attempts (cancels cleanly on context done).
- Track `Attempts` / `MaxAttempts` per test run (new fields on `TestRunSummary`).
- k6 now emits the per-test `bench_test_run_flaky` metric, matching gotest.
- The k6 retry loop coexists with the uncaught-script-exception detection added in #988.

**Metrics**
- `bench_test_run_flaky` (per-test, label `test_full_path`) — now emitted by k6 as well as gotest.
- `bench_test_retries_total` (**new**, suite labels only — no `test_full_path`) — total retry attempts across the suite, computed once in the Prometheus reporter from `Attempts`, so it is automatically consistent across all runners and stays low cardinality.

**Reporting / logs**
- `LogReporter` now includes `attempts` and `maxAttempts` on each `msg=testRun` event, so per-test retry detail lives in logs (the right home for high-cardinality, per-test data) rather than metric labels.

**Docs**
- `docs/writing_k6_api_tests.md` — retry usage.
- `docs/metrics.md` — documents both flaky/retry metrics with a cardinality note.
- Regenerated `docs/bench_test.md` CLI reference for the new flags.

## Metric design / cardinality

Three tiers, each at the right cardinality:

| Question | Where |
|---|---|
| Is flakiness trending up? | `bench_tests_flaky` (aggregate metric) |
| How much retry effort? | `bench_test_retries_total` (aggregate metric, **new**) |
| Which test, how many attempts? | `msg=testRun` logs (`attempts` / `maxAttempts`) |

Attempt counts are intentionally **not** metric labels (numbers-as-labels is a Prometheus anti-pattern); they live in logs.

## Unblocks #961

`bench analyze` (#961) confirms a defect only on consecutive `failed`/`error` runs and deliberately **excludes `flaky`** so flaky tests are not mistaken for real regressions. That depends on bench actually retrying and re-labelling recovered tests as `flaky` — which this PR delivers, now consistently for k6. The `msg=testRun` field contract the analyzer reads (`status`, `grafanaVersion`, `service`, `runStage`, `testFile`, `exitMessage`) is unchanged; `attempts`/`maxAttempts` are additive.

## Testing

- Unit tests for k6 and gotest retry/flaky paths and attempt tracking.
- `sumRetries` unit test for the new aggregate metric.
- `go build ./...`, `go vet ./...`, and full `go test ./...` pass.
