### PR TITLE
fix(playwright): symlink chromium so k6 auto-detects it

### DIFF
--- a/Dockerfile-playwright
+++ b/Dockerfile-playwright
@@ -56,6 +56,13 @@ RUN corepack install -g npm@latest yarn@latest pnpm@latest
 
 # Use existing pwuser from Playwright base image instead of creating bench user
 
+# Symlink the Playwright-managed chromium binary to stable names so k6's browser
+# module can auto-detect it via PATH. The Playwright path is version-pinned
+# (e.g. /ms-playwright/chromium-1208/chrome-linux/chrome), so resolving the glob
+# at build time avoids hardcoding it in K6_BROWSER_EXECUTABLE_PATH downstream.
+RUN ln -s /ms-playwright/chromium-*/chrome-linux/chrome /usr/bin/chromium-browser && \
+  ln -s /ms-playwright/chromium-*/chrome-linux/chrome /usr/bin/chromium
+
 # Copy binaries
 COPY --from=k6 /usr/bin/k6 /usr/local/bin/k6
 COPY --from=builder /app/build/grafana-bench /usr/local/bin/grafana-bench

--- a/Dockerfile-playwright.dev
+++ b/Dockerfile-playwright.dev
@@ -58,6 +58,13 @@ RUN corepack install -g npm@latest yarn@latest pnpm@latest
 
 # Use existing pwuser from Playwright base image instead of creating bench user
 
+# Symlink the Playwright-managed chromium binary to stable names so k6's browser
+# module can auto-detect it via PATH. The Playwright path is version-pinned
+# (e.g. /ms-playwright/chromium-1208/chrome-linux/chrome), so resolving the glob
+# at build time avoids hardcoding it in K6_BROWSER_EXECUTABLE_PATH downstream.
+RUN ln -s /ms-playwright/chromium-*/chrome-linux/chrome /usr/bin/chromium-browser && \
+  ln -s /ms-playwright/chromium-*/chrome-linux/chrome /usr/bin/chromium
+
 # Copy binaries
 COPY --from=k6 /usr/bin/k6 /usr/local/bin/k6
 COPY --from=builder /app/build/grafana-bench /usr/local/bin/grafana-bench


### PR DESCRIPTION
## Summary
- Symlink the version-pinned Playwright chromium binary to `/usr/bin/chromium-browser` and `/usr/bin/chromium` so k6's browser module finds it on PATH out of the box.
- Resolves the glob (`/ms-playwright/chromium-*/chrome-linux/chrome`) once at build time, so the fix survives Playwright base-image bumps without consumers having to update `K6_BROWSER_EXECUTABLE_PATH`.
- Applied to both `Dockerfile-playwright` and `Dockerfile-playwright.dev`.

Fixes #949

## Test plan
Verified locally against a freshly built `grafana-bench-playwright` image:

- [x] `ls -la /usr/bin/chromium /usr/bin/chromium-browser` → both symlinks resolve to a real chrome binary
- [x] `/usr/bin/chromium-browser --version --no-sandbox` prints a Chromium version (proves the glob resolved at build time)
- [x] k6 browser smoke test (\`import { browser } from 'k6/browser'\`) — passes **without** setting \`K6_BROWSER_EXECUTABLE_PATH\`
- [x] Existing Playwright login test against a Grafana container — still passes (no regression for the Playwright executor path)

## Notes
- The issue also suggested adding \`disable-dev-shm-usage,disable-gpu\` to \`K6_BROWSER_ARGS\`. After checking, the [official k6 Dockerfile](https://github.com/grafana/k6/blob/master/Dockerfile) actually only sets \`no-sandbox\` — which is what \`pkg/executor/k6/k6_executor.go:401\` already does. The k6 browser test passes with just \`no-sandbox\`, so I didn't change the executor.