### PR TITLE
ci: pass permission_set: update-libsonnet to GATB action

### DIFF
--- a/.github/workflows/update-libsonnet.yml
+++ b/.github/workflows/update-libsonnet.yml
@@ -58,6 +58,7 @@ jobs:
         uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
         with:
           github_app: updater-for-ci
+          permission_set: update-libsonnet
 
       - name: generate libsonnet
         env:


### PR DESCRIPTION
## Summary

Follow-up to #980. The GATB action uses `github.workflow_ref` (the caller, = `ci.yml`) for its Vault role lookup, not this reusable workflow's own path. Companion `deployment_tools` config moves the entry to `path: ci.yml` under a distinct permission-set name; we have to pass `permission_set: update-libsonnet` here so the action requests the right role.

Depends on https://github.com/grafana/deployment_tools/pull/597629 being applied first.

## Test plan

- [ ] Companion deployment_tools PR (#597629) merged + atlantis applied.
- [ ] Push to main; `update-experimental-libsonnet / update-libsonnet` job goes green.
- [ ] Auto-PR appears in `deployment_tools` under `auto-merge/bench-libsonnet-experimental`.