### PR TITLE
ci: set updater updater-for-ci[bot]

### DIFF
--- a/.github/workflows/update-libsonnet.yml
+++ b/.github/workflows/update-libsonnet.yml
@@ -153,6 +153,10 @@ jobs:
           {
             "repo_owner": "grafana",
             "repo_name": "deployment_tools",
+            "git_author_name": "updater-for-ci[bot]",
+            "git_author_email": "119986603+updater-for-ci[bot]@users.noreply.github.com",
+            "git_committer_name": "updater-for-ci[bot]",
+            "git_committer_email": "119986603+updater-for-ci[bot]@users.noreply.github.com",
             "destination_branch": "master",
             "pull_request_enabled": true,
             "pull_request_branch_prefix": "${BRANCH_PREFIX}",


### PR DESCRIPTION
## Summary

The libsonnet auto-PR into deployment_tools is now created successfully (PR #597673 last run), but deployment_tools' auto-merge job fails with:

```
##[error]Commit authored by 'grafanabot', expected 'updater-for-ci[bot]'.
Will not auto-approve.
```

The auto-merge action requires the commit's git author to match the GitHub user that opened the PR. The PR is opened by `updater-for-ci[bot]` (GATB installation token), but the updater Docker plugin defaults the git author/committer to `grafanabot`.

Fix: pass `git_author_*` and `git_committer_*` overrides in the updater config.json so commits are authored by the same App identity that opens the PR. Pattern copied from deployment_tools' own `update-alloy-db-o11y.yml` and `kube-manifests-exporter.yaml` workflows.

## Test plan

- [ ] Merge, push to main, observe `update-experimental-libsonnet` opens a new PR in deployment_tools.
- [ ] Verify that PR's `auto-merge` job runs green and the PR auto-merges (instead of stopping at the "Will not auto-approve" check).