### PR TITLE
ci: fix prometheus polling path, bump timeout, add HTTP diagnostics

### DIFF
--- a/.github/workflows/update-libsonnet.yml
+++ b/.github/workflows/update-libsonnet.yml
@@ -214,69 +214,75 @@ jobs:
           TEST_VERSION_SHA: ${{ inputs.test_version_sha }}
         run: |
           set -euo pipefail
-          
-          echo "🔍 Waiting for deployment metrics to appear in Prometheus..."
-          
-          # For versioned releases use the version string; for experimental use the commit SHA
+
           if [ -n "$TEST_VERSION_SHA" ]; then
             TARGET_SHA="$TEST_VERSION_SHA"
-            echo "Using test version SHA: $TARGET_SHA"
           elif [ "$VERSION" != "experimental" ]; then
             TARGET_SHA="$VERSION"
-            echo "Using version string: $TARGET_SHA"
           else
             TARGET_SHA=$(git rev-parse HEAD)
-            echo "Using current commit SHA: $TARGET_SHA"
           fi
-          
-          # Convert timeout to seconds
-          TIMEOUT_SECONDS=1800  # 30 minutes
-          POLL_INTERVAL=10      # 10 seconds
-          
+
+          TIMEOUT_SECONDS=2700  # 45 minutes; covers libsonnet PR auto-merge + kube-manifests-exporter + flux + scrape
+          POLL_INTERVAL=10
+
           QUERY="argo_resource_info{exported_namespace=\"grafana-bench-cd\", version=\"$TARGET_SHA\"}"
-          
+          # PROMETHEUS_URL is the bare hostname; the Mimir Cortex-compat PromQL endpoint lives at /api/prom/api/v1/query.
+          PROM_QUERY_URL="${PROMETHEUS_URL}/api/prom/api/v1/query"
+
           echo "Target SHA: $TARGET_SHA"
           echo "Query: $QUERY"
-          echo "Timeout: 30 minutes, checking every ${POLL_INTERVAL}s"
+          echo "URL: $PROM_QUERY_URL"
+          echo "Timeout: ${TIMEOUT_SECONDS}s, polling every ${POLL_INTERVAL}s"
           echo ""
-          
-          # Test the query once first
-          PROMETHEUS_RESPONSE=$(curl -s -G "$PROMETHEUS_URL/prometheus/api/v1/query" \
-            --data-urlencode "query=$QUERY" \
-            -u "$PROMETHEUS_USER:$PROMETHEUS_TOKEN")
-          
-          RESULT_COUNT=$(echo "$PROMETHEUS_RESPONSE" | jq -r '.data.result | length' 2>/dev/null || echo "0")
-          
-          if [ "$RESULT_COUNT" -gt "0" ]; then
-            echo "✅ Success! Found $RESULT_COUNT metric(s) with version $TARGET_SHA"
-            echo "🎉 Deployment detected immediately"
-            exit 0
-          fi
-          
-          # Start polling
-          echo "🔄 Starting polling..."
+
           ELAPSED=0
-          while [ $ELAPSED -lt $TIMEOUT_SECONDS ]; do
-            ATTEMPT_NUM=$(($ELAPSED / $POLL_INTERVAL + 1))
-            echo "⏳ Attempt $ATTEMPT_NUM (${ELAPSED}s elapsed)..."
-            
-            PROMETHEUS_RESPONSE=$(curl -s -G "$PROMETHEUS_URL/prometheus/api/v1/query" \
+          ATTEMPT=0
+          while [ "$ELAPSED" -lt "$TIMEOUT_SECONDS" ]; do
+            ATTEMPT=$((ATTEMPT + 1))
+
+            RESPONSE=$(mktemp)
+            HTTP_STATUS=$(curl -sS -G -o "$RESPONSE" -w "%{http_code}" "$PROM_QUERY_URL" \
               --data-urlencode "query=$QUERY" \
-              -u "$PROMETHEUS_USER:$PROMETHEUS_TOKEN")
-            
-            RESULT_COUNT=$(echo "$PROMETHEUS_RESPONSE" | jq -r '.data.result | length' 2>/dev/null || echo "0")
-            
-            if [ "$RESULT_COUNT" -gt "0" ]; then
-              echo "✅ Success! Found $RESULT_COUNT metric(s) with version $TARGET_SHA"
-              echo "🎉 Deployment detected after ${ELAPSED}s"
+              -u "$PROMETHEUS_USER:$PROMETHEUS_TOKEN" || echo "000")
+
+            COUNT=0
+            if [ "$HTTP_STATUS" = "200" ]; then
+              COUNT=$(jq -r '.data.result | length // 0' "$RESPONSE" 2>/dev/null || echo "0")
+            fi
+
+            if [ "$COUNT" -gt 0 ]; then
+              echo "✅ Found $COUNT metric(s) for version $TARGET_SHA after ${ELAPSED}s (HTTP $HTTP_STATUS)"
+              rm -f "$RESPONSE"
               exit 0
             fi
-            
-            sleep $POLL_INTERVAL
-            ELAPSED=$(($ELAPSED + $POLL_INTERVAL))
+
+            # Auth or path failures won't get better by waiting — fail fast with the body so it's debuggable.
+            case "$HTTP_STATUS" in
+              401|403|404)
+                echo "❌ Prometheus query failed with HTTP $HTTP_STATUS (URL: $PROM_QUERY_URL)"
+                echo "Response (first 500 chars):"
+                head -c 500 "$RESPONSE"; echo
+                rm -f "$RESPONSE"
+                exit 1
+                ;;
+            esac
+
+            # Log status on the first attempt and once per minute thereafter; include a snippet on non-200.
+            if [ "$ATTEMPT" = "1" ] || [ "$((ATTEMPT % 6))" = "0" ]; then
+              echo "⏳ Attempt $ATTEMPT (${ELAPSED}s): HTTP $HTTP_STATUS, $COUNT results"
+              if [ "$HTTP_STATUS" != "200" ]; then
+                echo "  Response (first 300 chars):"
+                head -c 300 "$RESPONSE" | sed 's/^/  /'; echo
+              fi
+            fi
+
+            rm -f "$RESPONSE"
+            sleep "$POLL_INTERVAL"
+            ELAPSED=$((ELAPSED + POLL_INTERVAL))
           done
-          
-          echo "❌ Timeout: No metrics found after ${TIMEOUT_SECONDS}s"
+
+          echo "❌ Timeout: No matching metric after ${TIMEOUT_SECONDS}s"
           exit 1
 
       - name: setup argo


### PR DESCRIPTION
## Summary

Three fixes to the `wait for deployment metrics to appear` step in `update-libsonnet.yml`. Symptom from today's run was a 30-minute polling timeout even though the metric was visible in Prometheus 13 minutes before the deadline.

### 1. Wrong Prometheus API path

The workflow hard-codes `/prometheus/api/v1/query`, but the Mimir Cortex-compat endpoint at `prometheus-ops-03-ops-eu-south-0.grafana-ops.net` serves PromQL at `/api/prom/api/v1/query`. The wrong path returns a redirect/404, the old script's `jq … || echo "0"` silently treated that as "no results yet", and polling looped for the full timeout. Switched to the correct prefix; verified locally with `curl -i …/api/prom/api/v1/query …` → HTTP 200 with the expected metric.

### 2. Timeout too tight

`TIMEOUT_SECONDS=1800` (30 min) was budgeted against:
- ~20 min for the libsonnet PR to auto-merge (review + CI checks)
- ~6 min for kube-manifests-exporter to render and push
- ~3–5 min for Flux sync → kube-state-metrics scrape → Prometheus

That's ~30 min with zero buffer. Bumped to `2700` (45 min) for ~15 min of headroom in the healthy path.

### 3. Silent failures

The old polling masked all non-success responses as "no results, retry":
```bash
RESULT_COUNT=$(echo "$RESP" | jq -r '.data.result | length' 2>/dev/null || echo "0")
```

A 401 looked identical to "metric not ingested yet". Today's incident was a 401 (Grafana Cloud access policy missing `metrics:read`); the script would have happily polled the whole 30 min without surfacing it. New behavior:

- Capture `HTTP_STATUS` via `curl -w "%{http_code}"`.
- On `401`/`403`/`404`: fail fast with a body snippet — these never resolve by waiting.
- Otherwise: log status + result count + body snippet (on non-200) once per minute.

## Test plan

- [ ] Merge; on next push to `main`, observe `update-experimental-libsonnet` reaches the polling step.
- [ ] Confirm polling succeeds (HTTP 200, `>0` results) within the timeout once the WorkflowTemplate is deployed with the new `version` label.
- [ ] On any future regression, the per-minute log line should make the cause (path, auth, or genuine delay) obvious.