### PR TITLE
fix(k6): fail on uncaught script exceptions

### DIFF
--- a/pkg/executor/k6/k6_executor.go
+++ b/pkg/executor/k6/k6_executor.go
@@ -34,6 +34,14 @@ var (
 	missingK6CloudConfigError = errors.New("k6 Token and project ID are required for cloud output")
 	testFilesError            = errors.New("getting test files")
 	testExts                  = []string{".js", ".ts"}
+	// k6 logs an uncaught script exception with a `source=stacktrace` field but
+	// still exits 0, so this field is the only reliable signal that a VU threw.
+	// Match both the default logfmt output and the JSON log format
+	// (--log-format=json) so detection survives a log-format change.
+	k6ScriptErrorMarkers = [][]byte{
+		[]byte("source=stacktrace"),
+		[]byte(`"source":"stacktrace"`),
+	}
 	// used to replace strings.Title
 	caser = cases.Title(language.AmericanEnglish)
 )
@@ -259,6 +267,20 @@ func (t *K6TestExecutor) execTest(
 		}
 	}
 
+	// k6 exits 0 when a VU throws an uncaught exception during an iteration: the
+	// error is logged with `source=stacktrace` and the iteration is counted as
+	// failed, but the run itself is not. Without this check such a test would be
+	// silently reported as passed.
+	if status == executor.TestPassed && hasK6ScriptError(buf.Bytes()) {
+		status = executor.TestError
+		cmdErr = "k6 reported an uncaught script exception (see stacktrace in output)"
+		t.Log.Error(cmdErr)
+		// surface the output that wasn't printed above (k6 exited 0)
+		if !t.Verbose {
+			fmt.Println(buf.String())
+		}
+	}
+
 	if status != executor.TestError {
 		output, err = t.getOutput(buf, jsonFile, scenarioName)
 	}
@@ -272,6 +294,18 @@ func (t *K6TestExecutor) execTest(
 		CloudID:     output.cloudId,
 		CloudURL:    output.cloudURL,
 	}, err
+}
+
+// hasK6ScriptError reports whether k6's output contains an uncaught script
+// exception. k6 logs these with a `source=stacktrace` field but still exits 0,
+// so scanning the output is the only reliable signal.
+func hasK6ScriptError(output []byte) bool {
+	for _, marker := range k6ScriptErrorMarkers {
+		if bytes.Contains(output, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // pattern to match k6 version output

--- a/pkg/executor/k6/k6_executor_test.go
+++ b/pkg/executor/k6/k6_executor_test.go
@@ -58,6 +58,40 @@ func k6TestRunnerForTesting(
 	return te, nil
 }
 
+func TestHasK6ScriptError(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		output string
+		expect bool
+	}{
+		{
+			name:   "logfmt stacktrace",
+			output: `time="..." level=error msg="TypeError: ..." executor=per-vu-iterations scenario=default source=stacktrace`,
+			expect: true,
+		},
+		{
+			name:   "json stacktrace",
+			output: `{"level":"error","msg":"TypeError: ...","source":"stacktrace"}`,
+			expect: true,
+		},
+		{
+			name:   "clean passing output",
+			output: "running (00m00.0s), 0/1 VUs, 1 complete and 0 interrupted iterations",
+			expect: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, "has script error", tc.expect, hasK6ScriptError([]byte(tc.output)))
+		})
+	}
+}
+
 func TestK6Executor(t *testing.T) {
 	t.Parallel()
 
@@ -116,6 +150,19 @@ func TestK6Executor(t *testing.T) {
 			},
 		},
 		{
+			// k6 exits 0 on an uncaught script exception; bench must still
+			// surface it as an error rather than a pass.
+			testCase:  "script exception test",
+			testSuite: "k6tests/exception.js",
+			expect: &executor.SuiteRunSummary{
+				TestsExecuted: 1,
+				TestsError:    1,
+				TestRuns: []executor.TestRunSummary{
+					{TestFile: "exception.js", Status: executor.TestError},
+				},
+			},
+		},
+		{
 			testCase:  "missing test",
 			testSuite: "k6tests/missing.js",
 			expectErr: testFilesError,
@@ -124,12 +171,13 @@ func TestK6Executor(t *testing.T) {
 			testCase:  "test suite directory",
 			testSuite: "k6tests/",
 			expect: &executor.SuiteRunSummary{
-				TestsExecuted: 3,
-				TestsError:    1,
+				TestsExecuted: 4,
+				TestsError:    2,
 				TestsFailed:   1,
 				TestsPassed:   1,
 				TestRuns: []executor.TestRunSummary{
 					{TestFile: "abort.js", Status: executor.TestError},
+					{TestFile: "exception.js", Status: executor.TestError},
 					{TestFile: "fail.js", Status: executor.TestFailed},
 					{TestFile: "pass.js", Status: executor.TestPassed},
 				},
@@ -144,7 +192,7 @@ func TestK6Executor(t *testing.T) {
 			testSuite: "k6tests/pass.js",
 			expect: &executor.SuiteRunSummary{
 				TestsExecuted: 1,
-				TestsError:   1,
+				TestsError:    1,
 				TestRuns: []executor.TestRunSummary{
 					{TestFile: "pass.js", Status: executor.TestError},
 				},

--- a/pkg/executor/k6/k6tests/exception.js
+++ b/pkg/executor/k6/k6tests/exception.js
@@ -1,0 +1,7 @@
+// Throws an uncaught exception inside the iteration. k6 logs the error with
+// `source=stacktrace` and still exits 0, so bench must detect it to avoid
+// reporting the test as passed.
+export default function () {
+  const client = undefined;
+  client.request('GET', 'http://localhost');
+}


### PR DESCRIPTION
## Problem

k6 returns **exit code 0** when a VU throws an uncaught exception *during an iteration*. The error is logged with `source=stacktrace` and the iteration is counted as failed, but the run itself is not failed. bench derived its pass/fail status only from k6's exit code, so these tests were **silently reported as passed**.

This is exactly how the CI `api_test.ts` `TypeError` (fixed in #986) hid for over a year — the suite reported `status=passed, anyFailures=false` every run.

Empirically confirmed (k6 v1.6.1 and v2.0.0):

| Scenario | k6 exit | Handled before? |
|---|---|---|
| Exception in `default()` (iteration) | **0** | ❌ reported passed |
| Exception in init / `setup()` / teardown | 107 | ✅ already → `TestError` |
| Threshold failed | 99 | ✅ → `TestFailed` |
| `exec.test.abort()` | 108 | ✅ → `TestError` |

So only the in-iteration case slipped through.

## Fix

In `pkg/executor/k6/k6_executor.go`, after the run, if k6 exited cleanly (status still `TestPassed`) **and** the captured output contains the `source=stacktrace` marker, mark the test `TestError`. Thresholds can't reliably cover this (an exception that throws before any `check()`/request produces zero samples, so nothing fails), making output detection the robust signal.

Adds a `k6tests/exception.js` fixture and a `script exception test` case, and updates the directory-suite case accordingly. All executor/parser tests pass.

## Note

This branch also carries the k6 image pin (`latest` → `2.0.0`) from #987, per request — so #987 is now redundant and can be closed in favor of this PR.