### PR TITLE
fix(playwright): install npm directly so runtime npm is latest

### DIFF
--- a/Dockerfile-playwright
+++ b/Dockerfile-playwright
@@ -47,12 +47,22 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-# Enable corepack and install pnpm (Node.js already included in Playwright base image)
+# Enable corepack and install package managers (Node.js already included in Playwright base image)
 RUN npm uninstall -g yarn pnpm # remove default yarn and pnpm
 RUN npm install -g corepack@latest
 RUN corepack enable # enable corepack
-# install corepack packagemanagers
-RUN corepack install -g npm@latest yarn@latest pnpm@latest
+# corepack does not shim npm, so `corepack install -g npm@latest` is a no-op for the
+# npm used at runtime — the Node-bundled npm would silently win on PATH (see #1003).
+# Install npm directly so the freshly installed global npm takes precedence, and let
+# corepack manage yarn/pnpm (which it does shim).
+RUN npm install -g npm@latest
+RUN corepack install -g yarn@latest pnpm@latest
+# Assert the shipped npm matches the latest published version so it can't silently
+# drift behind what this Dockerfile intends to ship.
+RUN installed="$(npm --version)" && latest="$(npm view npm version)" \
+  && echo "npm installed=${installed} latest=${latest}" \
+  && [ "${installed}" = "${latest}" ] \
+  || (echo "ERROR: shipped npm ${installed} does not match latest ${latest}" && exit 1)
 
 # Use existing pwuser from Playwright base image instead of creating bench user
 

--- a/Dockerfile-playwright.dev
+++ b/Dockerfile-playwright.dev
@@ -49,12 +49,22 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-# Enable corepack and install pnpm (Node.js already included in Playwright base image)
+# Enable corepack and install package managers (Node.js already included in Playwright base image)
 RUN npm uninstall -g yarn pnpm # remove default yarn and pnpm
 RUN npm install -g corepack@latest
 RUN corepack enable # enable corepack
-# install corepack packagemanagers
-RUN corepack install -g npm@latest yarn@latest pnpm@latest
+# corepack does not shim npm, so `corepack install -g npm@latest` is a no-op for the
+# npm used at runtime — the Node-bundled npm would silently win on PATH (see #1003).
+# Install npm directly so the freshly installed global npm takes precedence, and let
+# corepack manage yarn/pnpm (which it does shim).
+RUN npm install -g npm@latest
+RUN corepack install -g yarn@latest pnpm@latest
+# Assert the shipped npm matches the latest published version so it can't silently
+# drift behind what this Dockerfile intends to ship.
+RUN installed="$(npm --version)" && latest="$(npm view npm version)" \
+  && echo "npm installed=${installed} latest=${latest}" \
+  && [ "${installed}" = "${latest}" ] \
+  || (echo "ERROR: shipped npm ${installed} does not match latest ${latest}" && exit 1)
 
 # Use existing pwuser from Playwright base image instead of creating bench user
 


### PR DESCRIPTION
## Summary

`Dockerfile-playwright` (and `Dockerfile-playwright.dev`) installed npm via `corepack install -g npm@latest`, but **corepack does not shim `npm`**, so that command is a no-op for the npm used at runtime. The Node-bundled npm from the Playwright base image (`mcr.microsoft.com/playwright:v1.58.2-noble` → npm **11.6.2** on node 24.13.0) silently wins on PATH, despite the image advertising it ships latest.

This makes `npm ci` fail with `EBADENGINE` during a bench run's "prepare codebase" step for any consuming plugin that sets a recent `engines.npm` floor together with `engine-strict=true` in `.npmrc`:

```
npm error code EBADENGINE
npm error notsup Required: {"node":">=24","npm":">=11.12.1"}
npm error notsup Actual:   {"npm":"11.6.2","node":"v24.13.0"}
```

Fixes #1003.

## Changes

- Install npm directly with `npm install -g npm@latest` so the freshly installed global npm takes PATH precedence over the Node-bundled one.
- Keep corepack managing `yarn`/`pnpm` (corepack *does* shim those).
- Add a build-time assertion that the shipped `npm --version` matches the latest published version, so the npm can't silently drift behind what the Dockerfile intends to ship.

Applied identically to `Dockerfile-playwright` and `Dockerfile-playwright.dev`.

## Verification

Built against the real base image (`mcr.microsoft.com/playwright:v1.58.2-noble`):

- Baseline bundled npm: `11.6.2` (node `v24.13.0`) — the bug.
- After the old `corepack install -g npm@latest`: `npm --version` still reports `11.6.2` — confirming the no-op.
- After `npm install -g npm@latest`: `npm --version` reports `11.17.0`, and the new build-time assertion (`installed == latest`) passes.