### PR TITLE
fix(docker): bump playwright base image to v1.62.1-noble for Node 24.15+

### DIFF
--- a/Dockerfile-playwright
+++ b/Dockerfile-playwright
@@ -35,7 +35,7 @@ RUN CGO_ENABLED=0 go build \
 FROM grafana/k6:2.0.0 AS k6
 
 # Use Playwright base image which includes all browser dependencies
-FROM mcr.microsoft.com/playwright:v1.58.2-noble AS runtime
+FROM mcr.microsoft.com/playwright:v1.62.1-noble AS runtime
 
 USER root
 
@@ -68,10 +68,10 @@ RUN installed="$(npm --version)" && latest="$(npm view npm version)" \
 
 # Symlink the Playwright-managed chromium binary to stable names so k6's browser
 # module can auto-detect it via PATH. The Playwright path is version-pinned
-# (e.g. /ms-playwright/chromium-1208/chrome-linux/chrome), so resolving the glob
+# (e.g. /ms-playwright/chromium-1234/chrome-linux64/chrome), so resolving the glob
 # at build time avoids hardcoding it in K6_BROWSER_EXECUTABLE_PATH downstream.
-RUN ln -s /ms-playwright/chromium-*/chrome-linux/chrome /usr/bin/chromium-browser && \
-  ln -s /ms-playwright/chromium-*/chrome-linux/chrome /usr/bin/chromium
+RUN ln -s /ms-playwright/chromium-*/chrome-linux64/chrome /usr/bin/chromium-browser && \
+  ln -s /ms-playwright/chromium-*/chrome-linux64/chrome /usr/bin/chromium
 
 # Copy binaries
 COPY --from=k6 /usr/bin/k6 /usr/local/bin/k6

--- a/Dockerfile-playwright.dev
+++ b/Dockerfile-playwright.dev
@@ -37,7 +37,7 @@ RUN go get github.com/boxboat/fixuid@${FIXUID_VERSION} && \
 FROM grafana/k6:2.0.0 AS k6
 
 # Use Playwright base image which includes all browser dependencies
-FROM mcr.microsoft.com/playwright:v1.58.2-noble AS runtime
+FROM mcr.microsoft.com/playwright:v1.62.1-noble AS runtime
 
 USER root
 
@@ -70,10 +70,10 @@ RUN installed="$(npm --version)" && latest="$(npm view npm version)" \
 
 # Symlink the Playwright-managed chromium binary to stable names so k6's browser
 # module can auto-detect it via PATH. The Playwright path is version-pinned
-# (e.g. /ms-playwright/chromium-1208/chrome-linux/chrome), so resolving the glob
+# (e.g. /ms-playwright/chromium-1234/chrome-linux64/chrome), so resolving the glob
 # at build time avoids hardcoding it in K6_BROWSER_EXECUTABLE_PATH downstream.
-RUN ln -s /ms-playwright/chromium-*/chrome-linux/chrome /usr/bin/chromium-browser && \
-  ln -s /ms-playwright/chromium-*/chrome-linux/chrome /usr/bin/chromium
+RUN ln -s /ms-playwright/chromium-*/chrome-linux64/chrome /usr/bin/chromium-browser && \
+  ln -s /ms-playwright/chromium-*/chrome-linux64/chrome /usr/bin/chromium
 
 # Copy binaries
 COPY --from=k6 /usr/bin/k6 /usr/local/bin/k6


### PR DESCRIPTION
The playwright image build (`build-playwright-image / test-container-playwright`) is failing on every branch:

```
npm error code EBADENGINE
npm error Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error Actual:   {"npm":"11.6.2","node":"v24.13.0"}
ERROR: process "/bin/sh -c npm install -g npm@latest" did not complete successfully: exit code: 1
```

`npm install -g npm@latest` now floats to **npm 12.0.2**, whose engine requires Node `^24.15.0`, but the pinned base image `mcr.microsoft.com/playwright:v1.58.2-noble` ships **Node 24.13.0**. The build has no npm version compatible with the shipped Node, so it fails hard.

## What changed

- Bump the runtime base image `v1.58.2-noble` → `v1.62.1-noble` in both `Dockerfile-playwright` and `Dockerfile-playwright.dev`. That image ships **Node 24.18.1**, which satisfies npm@12.
- The newer Playwright image moves the bundled chromium binary from `chrome-linux/` to `chrome-linux64/`, so update the k6 browser auto-detect symlink glob to match. Without this the `ln -s` would silently create a dangling link and break browser detection at runtime.

## User-facing impact

The playwright image ships newer bundled browsers (Playwright 1.58 → 1.62). No bench CLI/flag changes.

## Verification

Local `docker build --platform linux/amd64` of `Dockerfile-playwright.dev` (matching CI):

- image builds cleanly, `npm install -g npm@latest` + the `installed == latest` assertion both pass
- `node --version` → `v24.18.1`, `npm --version` → `12.0.2`
- both `/usr/bin/chromium` and `/usr/bin/chromium-browser` resolve to `/ms-playwright/chromium-1234/chrome-linux64/chrome` (not dangling)
- `grafana-bench` and `k6` binaries present