### PR TITLE
feat(analyze): add plugin-version axis via --analyze-version-axis

### DIFF
--- a/cmd/analyze/command.go
+++ b/cmd/analyze/command.go
@@ -14,13 +14,18 @@ import (
 
 const longDescription = `
 analyze subcommand queries Loki for msg=testRun events and emits msg=defectConfirmed
-events for (service, runStage, testFile, grafanaVersion) tuples that breach the
+events for (service, runStage, testFile, version) tuples that breach the
 defect-confirmation rule.
+
+The version axis is selected by --analyze-version-axis: 'grafanaVersion'
+(default) bisects on the Grafana build under test (the RRC/core path), while
+'serviceVersion' bisects on the data source plugin version carried from
+--service-version, which moves independently of the Grafana version.
 
 Rule (v2):
   1. Persistence:       ≥ --analyze-min-failures consecutive failing testRun
-                        events on the target grafanaVersion.
-  2. Regression boundary: the most recent prior grafanaVersion in the same
+                        events on the target version.
+  2. Regression boundary: the most recent prior distinct version in the same
                         runStage has ≥ --analyze-min-prior-passing passing
                         runs and 0 failures.
   3. Deterministic signature: the canonicalised exitMessage is stable across
@@ -53,6 +58,13 @@ grafana-bench analyze \
   --analyze-loki-url https://logs-prod-xxx.grafana.net \
   --analyze-loki-bearer-token "$BENCH_LOKI_BEARER_TOKEN" \
   --analyze-service grafana-athena-datasource \
+  --analyze-run-stage ci
+
+# bisect on the plugin version instead of the Grafana version:
+grafana-bench analyze \
+  --analyze-loki-url https://logs-prod-xxx.grafana.net \
+  --analyze-service grafana-clickhouse-datasource \
+  --analyze-version-axis serviceVersion \
   --analyze-run-stage ci
 `
 
@@ -100,6 +112,7 @@ func NewCmd(log *slog.Logger) *cobra.Command {
 			defects := analyzer.Analyze(filtered, analyzer.RuleConfig{
 				MinFailures:     cfg.MinFailures,
 				MinPriorPassing: cfg.MinPriorPassing,
+				VersionAxis:     cfg.VersionAxis,
 			}, cfg.Window, time.Now())
 
 			log.Debug("analysis complete", "defects", len(defects))
@@ -108,7 +121,8 @@ func NewCmd(log *slog.Logger) *cobra.Command {
 				for _, d := range defects {
 					log.Info("dry-run defect",
 						"testFile", d.TestFile,
-						"grafanaVersion", d.GrafanaVersion,
+						"versionAxis", d.VersionAxis,
+						"version", d.Version,
 						"priorPassingVersion", d.PriorPassingVersion,
 						"confidence", d.Confidence,
 						"retryExhausted", d.RetryExhausted,
@@ -151,6 +165,12 @@ func validateConfig(cfg *config.AnalyzeConfig) error {
 	}
 	if cfg.Window <= 0 {
 		return fmt.Errorf("--analyze-window must be positive")
+	}
+	switch cfg.VersionAxis {
+	case "", analyzer.VersionAxisGrafana, analyzer.VersionAxisService:
+	default:
+		return fmt.Errorf("--analyze-version-axis must be %q or %q, got %q",
+			analyzer.VersionAxisGrafana, analyzer.VersionAxisService, cfg.VersionAxis)
 	}
 	return nil
 }

--- a/cmd/analyze/command_test.go
+++ b/cmd/analyze/command_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -155,6 +156,135 @@ func TestAnalyzeCommandDryRunSuppressesEmission(t *testing.T) {
 	}
 	if stdout.Len() != 0 {
 		t.Errorf("expected empty stdout in dry-run mode, got:\n%s", stdout.String())
+	}
+}
+
+// TestAnalyzeCommandServiceVersionAxis is the acceptance test for the M1
+// plugin-version axis: datasource testRun fixtures carry serviceVersion (from
+// --service-version) and no grafanaVersion at all. With
+// --analyze-version-axis=serviceVersion the analyzer must confirm the seeded
+// plugin-version regression and emit the serviceVersion-keyed schema.
+func TestAnalyzeCommandServiceVersionAxis(t *testing.T) {
+	const (
+		svc         = "grafana-clickhouse-datasource"
+		goodVersion = "1.27.0"
+		badVersion  = "1.27.1"
+	)
+
+	start := time.Now().Add(-6 * time.Hour)
+	mk := func(offset time.Duration, version, status, exitMsg, runID string) map[string]any {
+		return map[string]any{
+			"time":           start.Add(offset).Format(time.RFC3339Nano),
+			"level":          "INFO",
+			"msg":            "testRun",
+			"service":        svc,
+			"runStage":       "ci",
+			"testFile":       "queries.spec.ts",
+			"folder":         "tests/e2e",
+			"serviceVersion": version,
+			"status":         status,
+			"exitMessage":    exitMsg,
+			"runId":          runID,
+		}
+	}
+	fixture := []map[string]any{
+		mk(0, goodVersion, "passed", "", "g-1"),
+		mk(10*time.Minute, goodVersion, "passed", "", "g-2"),
+		mk(20*time.Minute, badVersion, "failed", "query editor timeout pid=4711", "b-1"),
+		mk(30*time.Minute, badVersion, "failed", "query editor timeout pid=9001", "b-2"),
+		mk(40*time.Minute, badVersion, "failed", "query editor timeout pid=1234", "b-3"),
+	}
+
+	srv := startFakeLoki(t, fixture)
+	defer srv.Close()
+
+	var stdout bytes.Buffer
+	cmd := NewCmd(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	cmd.SetOut(&stdout)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{
+		"--analyze-loki-url", srv.URL,
+		"--analyze-service", svc,
+		"--analyze-version-axis", "serviceVersion",
+	})
+
+	if err := cmd.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("analyze command failed: %v", err)
+	}
+
+	events := parseJSONL(t, stdout.Bytes())
+	if len(events) != 1 {
+		t.Fatalf("expected 1 defectConfirmed event, got %d:\n%s", len(events), stdout.String())
+	}
+	d := events[0]
+
+	assertString(t, d, "msg", "defectConfirmed")
+	assertString(t, d, "service", svc)
+	assertString(t, d, "versionAxis", "serviceVersion")
+	assertString(t, d, "serviceVersion", badVersion)
+	assertString(t, d, "priorPassingVersion", goodVersion)
+	assertString(t, d, "confidence", "confirmed")
+	if v, ok := d["grafanaVersion"]; ok {
+		t.Errorf("expected no grafanaVersion field on the service axis, got %v", v)
+	}
+}
+
+// TestAnalyzeCommandDefaultAxisEmitsVersionAxis verifies the RRC path emits
+// the versionAxis discriminator without any other schema change.
+func TestAnalyzeCommandDefaultAxisEmitsVersionAxis(t *testing.T) {
+	start := time.Now().Add(-6 * time.Hour)
+	fixture := []map[string]any{
+		mkTestRun(start, "grafana-pro", "ci", "permissions.ts", "13.0.0-good", "passed", "", "g-1"),
+		mkTestRun(start.Add(10*time.Minute), "grafana-pro", "ci", "permissions.ts", "13.0.0-good", "passed", "", "g-2"),
+		mkTestRun(start.Add(20*time.Minute), "grafana-pro", "ci", "permissions.ts", "13.0.0-bad", "failed", "boom", "b-1"),
+		mkTestRun(start.Add(30*time.Minute), "grafana-pro", "ci", "permissions.ts", "13.0.0-bad", "failed", "boom", "b-2"),
+		mkTestRun(start.Add(40*time.Minute), "grafana-pro", "ci", "permissions.ts", "13.0.0-bad", "failed", "boom", "b-3"),
+	}
+
+	srv := startFakeLoki(t, fixture)
+	defer srv.Close()
+
+	var stdout bytes.Buffer
+	cmd := NewCmd(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	cmd.SetOut(&stdout)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{
+		"--analyze-loki-url", srv.URL,
+		"--analyze-service", "grafana-pro",
+	})
+
+	if err := cmd.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("analyze command failed: %v", err)
+	}
+
+	events := parseJSONL(t, stdout.Bytes())
+	if len(events) != 1 {
+		t.Fatalf("expected 1 defectConfirmed event, got %d:\n%s", len(events), stdout.String())
+	}
+	assertString(t, events[0], "versionAxis", "grafanaVersion")
+	assertString(t, events[0], "grafanaVersion", "13.0.0-bad")
+	if v, ok := events[0]["serviceVersion"]; ok {
+		t.Errorf("expected no serviceVersion field on the default axis, got %v", v)
+	}
+}
+
+// TestAnalyzeCommandRejectsInvalidVersionAxis verifies the flag only accepts
+// the two known axes.
+func TestAnalyzeCommandRejectsInvalidVersionAxis(t *testing.T) {
+	cmd := NewCmd(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{
+		"--analyze-loki-url", "http://localhost:3100",
+		"--analyze-service", "grafana-pro",
+		"--analyze-version-axis", "buildNumber",
+	})
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatal("expected validation error for invalid version axis, got nil")
+	}
+	if !strings.Contains(err.Error(), "--analyze-version-axis") {
+		t.Errorf("expected error to mention --analyze-version-axis, got: %v", err)
 	}
 }
 

--- a/docs/analyzing_defects.md
+++ b/docs/analyzing_defects.md
@@ -1,6 +1,11 @@
 # Detecting defects across runs with `bench analyze`
 
-`bench analyze` turns the logs that bench already emits into a signal about whether a failing test has caught a real defect. It queries Loki for `msg=testRun` events over a time window, applies a multi-part rule to each `(service, runStage, testFile, grafanaVersion)` tuple, and emits a new `msg=defectConfirmed` event on stdout for every tuple that breaches the rule.
+`bench analyze` turns the logs that bench already emits into a signal about whether a failing test has caught a real defect. It queries Loki for `msg=testRun` events over a time window, applies a multi-part rule to each `(service, runStage, testFile, version)` tuple, and emits a new `msg=defectConfirmed` event on stdout for every tuple that breaches the rule.
+
+The version the rule bisects on is chosen by `--analyze-version-axis`:
+
+- **`grafanaVersion`** (default) keys on the Grafana build under test — the RRC/core path, unchanged from earlier releases.
+- **`serviceVersion`** keys on the data source plugin's own version, carried from `--service-version` onto every `testRun` line. Plugin versions move independently of the Grafana version they run against, and datasource `testRun` lines carry no `grafanaVersion` at all — so this axis is the one that makes the analyzer produce results for plugin rollouts.
 
 This is the automated, pre-deploy counterpart to the `invest:tests` label on `grafana/support-escalations`: `invest:tests` says "a human decided this should have been caught by tests," and `msg=defectConfirmed` says "bench flagged this as a regression before a customer escalated it." Put together, they give Defect Escape Rate (DER) a precision side — *of the defects that escaped to customers, how many did bench catch first?*
 
@@ -10,7 +15,8 @@ This is the automated, pre-deploy counterpart to the `invest:tests` label on `gr
 
 Use `bench analyze` when you want to:
 
-- **Answer "did bench see this coming?"** after a customer escalation — run the analyzer over the escalation window and check whether a `msg=defectConfirmed` for the same `grafanaVersion` already exists in Loki.
+- **Answer "did bench see this coming?"** after a customer escalation — run the analyzer over the escalation window and check whether a `msg=defectConfirmed` for the same version already exists in Loki.
+- **Confirm plugin-version regressions on the progressive-delivery path** — run with `--analyze-version-axis serviceVersion` so a bad plugin promotion is bisected against the last plugin version with a clean green, regardless of which Grafana build it ran on.
 - **Feed DER dashboards** with an automated bench-emitted signal alongside the manual `invest:tests` tag.
 - **Replace ad-hoc bisection runs** against `grafana-dev.net` slugs. The analyzer already has every `(version, outcome, exitMessage)` triple it needs in Loki; there is no reason to re-run suites to produce the timeline by hand.
 
@@ -23,7 +29,7 @@ Don't use it for:
 
 ## How the rule works
 
-A `(service, runStage, testFile, grafanaVersion)` tuple breaches the rule and produces an event when the first two conditions hold; it is labelled a **confirmed defect** (rather than **suspected**) only when all four conditions hold.
+A `(service, runStage, testFile, version)` tuple breaches the rule and produces an event when the first two conditions hold; it is labelled a **confirmed defect** (rather than **suspected**) only when all four conditions hold. "Version" throughout means the value on the configured `--analyze-version-axis`; records with an empty value on that axis are skipped.
 
 ### 1. Persistence
 
@@ -33,7 +39,9 @@ The tail requirement — not "any 3 failures in the window" — prevents a histo
 
 ### 2. Regression boundary
 
-Walking back through prior `grafanaVersion`s **in the same `runStage`**, the most recent distinct version must have at least `--analyze-min-prior-passing` passing runs and **zero** failures. Default: **2**. If the prior version itself had any failures, the tuple doesn't clear the boundary and the defect is not confirmed.
+Walking back through prior versions **in the same `runStage`**, the most recent distinct version must have at least `--analyze-min-prior-passing` passing runs and **zero** failures. Default: **2**. If the prior version itself had any failures, the tuple doesn't clear the boundary and the defect is not confirmed.
+
+Ordering is by run time, not by semver comparison — correct as long as promotions arrive in release order, which they do on the wave pipeline.
 
 Scoping by `runStage` is load-bearing: it prevents a clean CI stream from being contaminated by a persistently-failing `nightly` or `rrc` stream running on the same build.
 
@@ -77,8 +85,10 @@ Every confirmed or suspected defect produces one `msg=defectConfirmed` line. It 
 | `runStage` | CI/nightly/rrc/local — the scoping axis from rule (2) |
 | `testFile` | Unit of regression |
 | `testFolder` | Folder the test lives in |
-| `grafanaVersion` | The version the rule fired on (the bad version) |
-| `priorPassingVersion` | The most recent distinct prior grafanaVersion with ≥ `min_prior_passing` green runs (the last-known-good) |
+| `versionAxis` | The axis the rule ran on: `grafanaVersion` or `serviceVersion` |
+| `grafanaVersion` | The version the rule fired on (the bad version). Present only on the `grafanaVersion` axis |
+| `serviceVersion` | The plugin version the rule fired on (the bad version). Present only on the `serviceVersion` axis |
+| `priorPassingVersion` | The most recent distinct prior version on the axis with ≥ `min_prior_passing` green runs (the last-known-good) |
 | `grafanaSlug` | Cluster identity for RRC dashboard joins |
 | `grafanaUrl` | Cluster URL |
 | `signatureHash` | 12-hex signature used to dedupe across runs |
@@ -127,7 +137,7 @@ Sample debug output:
 time=... level=DEBUG msg="querying loki for testRun events" selector="{service_name=~\".+\"} |= \"tool=bench\" |= \"msg=testRun\"" start=... end=...
 time=... level=DEBUG msg="loaded testRun records" pulled=184 after_filter=41
 time=... level=DEBUG msg="analysis complete" defects=1
-time=... level=INFO  msg="dry-run defect" testFile=permissions.ts grafanaVersion=13.0.0-23542128402 priorPassingVersion=13.0.0-23563050832 confidence=confirmed retryExhausted=true signatureHash=a9c0f1b2d345 confidenceRuns=4
+time=... level=INFO  msg="dry-run defect" testFile=permissions.ts versionAxis=grafanaVersion version=13.0.0-23542128402 priorPassingVersion=13.0.0-23563050832 confidence=confirmed retryExhausted=true signatureHash=a9c0f1b2d345 confidenceRuns=4
 ```
 
 ### Real emission
@@ -159,6 +169,7 @@ Because events land on stdout in the same shape as every other bench event, the 
 
 | Flag | Default | Use when |
 |---|---|---|
+| `--analyze-version-axis` | `grafanaVersion` | Set to `serviceVersion` for data source plugins on the progressive-delivery path. The plugin version comes from `--service-version`, so it is only meaningful once the CI job passes the real promoted plugin version through (a shared channel label like `rrc-fast` gives every run one version and no boundary can ever form). |
 | `--analyze-min-failures` | `3` | Raise (e.g. `5`) for noisy test suites — buys precision at the cost of catching slow-burn regressions later. Lower (e.g. `2`) only for low-frequency/nightly streams where waiting for 3 is >24h. |
 | `--analyze-min-prior-passing` | `2` | Raise to demand more confidence that the prior version was really green. Lower for streams with sparse per-version coverage. |
 | `--analyze-window` | `24h` | Match to your test cadence. For RRC-style streams running every 5 minutes, `24h` is plenty; for nightly-only streams, `7d` is more appropriate. |
@@ -222,7 +233,7 @@ Suggested additions:
   )
   ```
 
-- **Annotations** on the DER timeseries, one per `grafanaVersion`, so reviewers can see which deploys bench flagged before they escalated.
+- **Annotations** on the DER timeseries, one per version on the analysis axis (`grafanaVersion` for RRC panels, `serviceVersion` for plugin panels), so reviewers can see which deploys bench flagged before they escalated.
 
 - **A drill-down row** showing the `sourceRunIds`, `signatureHash`, and `exitMessageSample` for any defect in the current window — enabling one-click navigation to the raw `msg=testRun` lines.
 
@@ -234,8 +245,9 @@ Suggested additions:
 Start with `--analyze-emit=false --log-level DEBUG` and check:
 1. `pulled=N` — is the selector finding records at all? If `pulled=0`, your selector is wrong or the window is wrong.
 2. `after_filter=N` — is your `--analyze-service` value the canonical slug? Typos here silently filter everything out.
-3. The failing tail must be the **last** `min_failures` records for that `(testFile, grafanaVersion)`. A single green run at the tail resets the persistence check.
+3. The failing tail must be the **last** `min_failures` records for that `(testFile, version)`. A single green run at the tail resets the persistence check.
 4. The prior version needs **zero failures**, not just "enough passes." Check for flakes on the supposed last-known-good version — they disqualify it.
+5. On the `serviceVersion` axis, records with an empty `serviceVersion` are skipped — and if every run carries the same value (e.g. a channel label instead of the real plugin version), no regression boundary can form.
 
 **"Confidence is `suspected` but I think it's the same defect."**
 The canonicaliser is conservative — it won't normalise fragments it doesn't recognise. Inspect the raw `exitMessage` samples in the `msg=testRun` events for the failing runs and check what's varying. If it's a new category (e.g. a test-framework version number, a hostname), open an issue so the canonicalisation table can learn it.

--- a/docs/bench_analyze.md
+++ b/docs/bench_analyze.md
@@ -6,13 +6,18 @@ analyze testRun events in Loki and emit defectConfirmed events
 
 
 analyze subcommand queries Loki for msg=testRun events and emits msg=defectConfirmed
-events for (service, runStage, testFile, grafanaVersion) tuples that breach the
+events for (service, runStage, testFile, version) tuples that breach the
 defect-confirmation rule.
+
+The version axis is selected by --analyze-version-axis: 'grafanaVersion'
+(default) bisects on the Grafana build under test (the RRC/core path), while
+'serviceVersion' bisects on the data source plugin version carried from
+--service-version, which moves independently of the Grafana version.
 
 Rule (v2):
   1. Persistence:       ≥ --analyze-min-failures consecutive failing testRun
-                        events on the target grafanaVersion.
-  2. Regression boundary: the most recent prior grafanaVersion in the same
+                        events on the target version.
+  2. Regression boundary: the most recent prior distinct version in the same
                         runStage has ≥ --analyze-min-prior-passing passing
                         runs and 0 failures.
   3. Deterministic signature: the canonicalised exitMessage is stable across
@@ -54,6 +59,13 @@ grafana-bench analyze \
   --analyze-service grafana-athena-datasource \
   --analyze-run-stage ci
 
+# bisect on the plugin version instead of the Grafana version:
+grafana-bench analyze \
+  --analyze-loki-url https://logs-prod-xxx.grafana.net \
+  --analyze-service grafana-clickhouse-datasource \
+  --analyze-version-axis serviceVersion \
+  --analyze-run-stage ci
+
 ```
 
 ### Options
@@ -68,10 +80,12 @@ grafana-bench analyze \
                                            Overridden by the BENCH_LOKI_URL environment variable.
       --analyze-loki-username string       Basic-auth username for Loki. Overridden by BENCH_LOKI_USERNAME.
       --analyze-min-failures int           Persistence threshold: consecutive failing testRun events required to confirm a defect. (default 3)
-      --analyze-min-prior-passing int      Regression-boundary threshold: passing runs required on the most recent prior grafanaVersion. (default 2)
+      --analyze-min-prior-passing int      Regression-boundary threshold: passing runs required on the most recent prior distinct version on the analysis axis. (default 2)
       --analyze-output string              Output format for emitted defectConfirmed events ('json' or 'text'). (default "json")
       --analyze-run-stage string           Restrict analysis to a single runStage. Empty evaluates each observed stage independently.
       --analyze-service string             REQUIRED. Restrict analysis to testRun records with this service value.
+      --analyze-version-axis string        Version axis the rule groups and bisects on: 'grafanaVersion' (RRC/core Grafana builds)
+                                           or 'serviceVersion' (the data source plugin version carried from --service-version). (default "grafanaVersion")
       --analyze-window duration            Lookback window for the Loki query_range request. (default 24h0m0s)
   -h, --help                               help for analyze
 ```

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -20,18 +20,31 @@ const (
 	ConfidenceSuspected = "suspected"
 )
 
+// Version axes for RuleConfig.VersionAxis: which testRun field the rule
+// bisects on. Grafana is the RRC/core path and the default; Service keys on
+// the plugin's own version (--service-version), which moves independently of
+// the Grafana version it runs against.
+const (
+	VersionAxisGrafana = "grafanaVersion"
+	VersionAxisService = "serviceVersion"
+)
+
 // RuleConfig tunes the detection rule. Zero values fall back to the v1
 // defaults inside Analyze().
 type RuleConfig struct {
 	// MinFailures is the persistence threshold: how many consecutive failing
-	// runs on a (service, runStage, testFile, grafanaVersion) are required
-	// before we'll consider the failure persistent.
+	// runs on a (service, runStage, testFile, version) are required before
+	// we'll consider the failure persistent.
 	MinFailures int
 
 	// MinPriorPassing is the regression-boundary threshold: how many passing
-	// runs are required on the most recent prior distinct grafanaVersion for
-	// us to treat it as "known-good".
+	// runs are required on the most recent prior distinct version for us to
+	// treat it as "known-good".
 	MinPriorPassing int
+
+	// VersionAxis selects the version field the rule groups and bisects on:
+	// VersionAxisGrafana or VersionAxisService. Empty means VersionAxisGrafana.
+	VersionAxis string
 }
 
 func (r RuleConfig) withDefaults() RuleConfig {
@@ -41,17 +54,34 @@ func (r RuleConfig) withDefaults() RuleConfig {
 	if r.MinPriorPassing <= 0 {
 		r.MinPriorPassing = 2
 	}
+	if r.VersionAxis == "" {
+		r.VersionAxis = VersionAxisGrafana
+	}
 	return r
+}
+
+// versionOf returns the record's version on the configured axis.
+func (r RuleConfig) versionOf(rec TestRunRecord) string {
+	if r.VersionAxis == VersionAxisService {
+		return rec.ServiceVersion
+	}
+	return rec.GrafanaVersion
 }
 
 // ConfirmedDefect is the output of the rule engine — one per confirmed or
 // suspected defect. Emitters translate these into the msg=defectConfirmed
 // logfmt schema.
 type ConfirmedDefect struct {
-	Service              string
-	RunStage             string
-	TestFile             string
-	TestFolder           string
+	Service    string
+	RunStage   string
+	TestFile   string
+	TestFolder string
+	// Version is the value on the analysis axis the rule fired on (the bad
+	// version); VersionAxis records which axis that was. GrafanaVersion
+	// carries the same value only on the grafanaVersion axis, kept for
+	// consumers that predate VersionAxis.
+	Version              string
+	VersionAxis          string
 	GrafanaVersion       string
 	PriorPassingVersion  string
 	GrafanaSlug          string
@@ -77,7 +107,7 @@ type ConfirmedDefect struct {
 
 // Analyze applies the v1 defect-confirmation rule to a set of testRun records
 // and returns one ConfirmedDefect per detection. The returned slice is sorted
-// by (service, runStage, testFile, grafanaVersion) for deterministic output.
+// by (service, runStage, testFile, version) for deterministic output.
 func Analyze(records []TestRunRecord, cfg RuleConfig, window time.Duration, now time.Time) []ConfirmedDefect {
 	cfg = cfg.withDefaults()
 
@@ -89,7 +119,7 @@ func Analyze(records []TestRunRecord, cfg RuleConfig, window time.Duration, now 
 		}
 	}
 
-	// Group by (service, runStage, testFile). grafanaVersion is NOT part of
+	// Group by (service, runStage, testFile). The version axis is NOT part of
 	// the group key here — we need to see all versions for a test so we can
 	// locate the regression boundary.
 	type perTestKey struct {
@@ -123,16 +153,17 @@ func Analyze(records []TestRunRecord, cfg RuleConfig, window time.Duration, now 
 		if a.TestFile != b.TestFile {
 			return a.TestFile < b.TestFile
 		}
-		return a.GrafanaVersion < b.GrafanaVersion
+		return a.Version < b.Version
 	})
 
 	return defects
 }
 
 // evaluateTest runs the three-part rule for a single (service, runStage,
-// testFile) group, returning a defect per grafanaVersion that breaches it.
+// testFile) group, returning a defect per version on the configured axis
+// that breaches it.
 func evaluateTest(recs []TestRunRecord, cfg RuleConfig, window time.Duration, now time.Time) []ConfirmedDefect {
-	// Collapse runs per grafanaVersion in time order, so we can identify the
+	// Collapse runs per version in time order, so we can identify the
 	// "most recent prior distinct version" deterministically.
 	type versionBlock struct {
 		Version string
@@ -140,14 +171,15 @@ func evaluateTest(recs []TestRunRecord, cfg RuleConfig, window time.Duration, no
 	}
 	var blocks []versionBlock
 	for _, r := range recs {
-		if r.GrafanaVersion == "" {
+		version := cfg.versionOf(r)
+		if version == "" {
 			continue
 		}
-		if n := len(blocks); n > 0 && blocks[n-1].Version == r.GrafanaVersion {
+		if n := len(blocks); n > 0 && blocks[n-1].Version == version {
 			blocks[n-1].Records = append(blocks[n-1].Records, r)
 			continue
 		}
-		blocks = append(blocks, versionBlock{Version: r.GrafanaVersion, Records: []TestRunRecord{r}})
+		blocks = append(blocks, versionBlock{Version: version, Records: []TestRunRecord{r}})
 	}
 
 	// Aggregate per-version stats separately for the regression-boundary
@@ -163,13 +195,14 @@ func evaluateTest(recs []TestRunRecord, cfg RuleConfig, window time.Duration, no
 	}
 	stats := map[string]*versionStats{}
 	for _, r := range recs {
-		if r.GrafanaVersion == "" {
+		version := cfg.versionOf(r)
+		if version == "" {
 			continue
 		}
-		s := stats[r.GrafanaVersion]
+		s := stats[version]
 		if s == nil {
 			s = &versionStats{FirstSeen: r.Time, LastSeen: r.Time}
-			stats[r.GrafanaVersion] = s
+			stats[version] = s
 		}
 		if r.Time.Before(s.FirstSeen) {
 			s.FirstSeen = r.Time
@@ -293,12 +326,13 @@ func evaluateTest(recs []TestRunRecord, cfg RuleConfig, window time.Duration, no
 			sourceIDs = append(sourceIDs, r.RunID)
 		}
 
-		defects = append(defects, ConfirmedDefect{
+		defect := ConfirmedDefect{
 			Service:              blk.Records[0].Service,
 			RunStage:             blk.Records[0].RunStage,
 			TestFile:             blk.Records[0].TestFile,
 			TestFolder:           blk.Records[0].Folder,
-			GrafanaVersion:       blk.Version,
+			Version:              blk.Version,
+			VersionAxis:          cfg.VersionAxis,
 			PriorPassingVersion:  priorVersion,
 			GrafanaSlug:          tail[len(tail)-1].GrafanaSlug,
 			GrafanaURL:           tail[len(tail)-1].GrafanaURL,
@@ -315,7 +349,11 @@ func evaluateTest(recs []TestRunRecord, cfg RuleConfig, window time.Duration, no
 			AnalyzeWindow:        window,
 			AnalyzedAt:           now,
 			RuleVersion:          RuleVersion,
-		})
+		}
+		if cfg.VersionAxis == VersionAxisGrafana {
+			defect.GrafanaVersion = blk.Version
+		}
+		defects = append(defects, defect)
 		seenBadVersions[blk.Version] = true
 	}
 

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -254,6 +254,180 @@ func TestAnalyzeSignatureDriftNotRescuedByRetries(t *testing.T) {
 	}
 }
 
+// mkSvcRun mirrors mkRun for the datasource E2E path: serviceVersion is set
+// (from --service-version) and grafanaVersion is absent, exactly as on real
+// datasource testRun lines.
+func mkSvcRun(offset time.Duration, svcVersion, status, exitMsg, runID string) TestRunRecord {
+	return TestRunRecord{
+		Time:           baseTime.Add(offset),
+		Msg:            "testRun",
+		Service:        "grafana-clickhouse-datasource",
+		RunStage:       stageCI,
+		TestFile:       testFile,
+		Folder:         "tests/e2e",
+		ServiceVersion: svcVersion,
+		Status:         status,
+		ExitMessage:    exitMsg,
+		RunID:          runID,
+	}
+}
+
+func TestAnalyzeServiceVersionAxisCleanRegression(t *testing.T) {
+	records := []TestRunRecord{
+		mkSvcRun(0, "1.27.0", "passed", "", "run-1"),
+		mkSvcRun(1*time.Hour, "1.27.0", "passed", "", "run-2"),
+		mkSvcRun(2*time.Hour, "1.27.1", "failed", "query editor timeout pid=4711", "run-3"),
+		mkSvcRun(3*time.Hour, "1.27.1", "failed", "query editor timeout pid=9001", "run-4"),
+		mkSvcRun(4*time.Hour, "1.27.1", "failed", "query editor timeout pid=1234", "run-5"),
+	}
+
+	defects := Analyze(records, RuleConfig{VersionAxis: VersionAxisService}, 24*time.Hour, baseTime)
+	if len(defects) != 1 {
+		t.Fatalf("expected 1 confirmed defect on the service axis, got %d: %+v", len(defects), defects)
+	}
+	d := defects[0]
+	if d.Version != "1.27.1" {
+		t.Errorf("expected version %q, got %q", "1.27.1", d.Version)
+	}
+	if d.VersionAxis != VersionAxisService {
+		t.Errorf("expected versionAxis %q, got %q", VersionAxisService, d.VersionAxis)
+	}
+	if d.PriorPassingVersion != "1.27.0" {
+		t.Errorf("expected prior version %q, got %q", "1.27.0", d.PriorPassingVersion)
+	}
+	if d.GrafanaVersion != "" {
+		t.Errorf("expected empty grafanaVersion on the service axis, got %q", d.GrafanaVersion)
+	}
+	if d.Confidence != ConfidenceConfirmed {
+		t.Errorf("expected confirmed, got %q", d.Confidence)
+	}
+}
+
+func TestAnalyzeDefaultAxisSkipsRecordsWithoutGrafanaVersion(t *testing.T) {
+	// The M1 gap this change closes: datasource testRun lines carry no
+	// grafanaVersion, so on the default axis every record is skipped and no
+	// defect can ever confirm.
+	records := []TestRunRecord{
+		mkSvcRun(0, "1.27.0", "passed", "", "run-1"),
+		mkSvcRun(1*time.Hour, "1.27.0", "passed", "", "run-2"),
+		mkSvcRun(2*time.Hour, "1.27.1", "failed", "boom", "run-3"),
+		mkSvcRun(3*time.Hour, "1.27.1", "failed", "boom", "run-4"),
+		mkSvcRun(4*time.Hour, "1.27.1", "failed", "boom", "run-5"),
+	}
+
+	defects := Analyze(records, RuleConfig{}, 24*time.Hour, baseTime)
+	if len(defects) != 0 {
+		t.Fatalf("expected 0 defects on the default axis for records without grafanaVersion, got %d: %+v", len(defects), defects)
+	}
+}
+
+func TestAnalyzeServiceVersionAxisSingleVersionNoBoundary(t *testing.T) {
+	// Pre-W1.3 situation: --service-version carries a channel label, so every
+	// run shares one version and no regression boundary can form.
+	records := []TestRunRecord{
+		mkSvcRun(0, "rrc-fast", "passed", "", "run-1"),
+		mkSvcRun(1*time.Hour, "rrc-fast", "passed", "", "run-2"),
+		mkSvcRun(2*time.Hour, "rrc-fast", "failed", "boom", "run-3"),
+		mkSvcRun(3*time.Hour, "rrc-fast", "failed", "boom", "run-4"),
+		mkSvcRun(4*time.Hour, "rrc-fast", "failed", "boom", "run-5"),
+	}
+
+	defects := Analyze(records, RuleConfig{VersionAxis: VersionAxisService}, 24*time.Hour, baseTime)
+	if len(defects) != 0 {
+		t.Fatalf("expected 0 defects when all runs share one serviceVersion, got %d: %+v", len(defects), defects)
+	}
+}
+
+func TestAnalyzeServiceVersionAxisIgnoresGrafanaVersionChanges(t *testing.T) {
+	// The plugin version moves independently of the Grafana version. Bisecting
+	// on serviceVersion must pool passing runs across a Grafana bump; the
+	// grafana axis would see two thin blocks and find no boundary here.
+	mk := func(offset time.Duration, svcVersion, grafanaVersion, status, exitMsg, runID string) TestRunRecord {
+		r := mkSvcRun(offset, svcVersion, status, exitMsg, runID)
+		r.GrafanaVersion = grafanaVersion
+		return r
+	}
+	records := []TestRunRecord{
+		mk(0, "1.27.0", "13.0.0-100", "passed", "", "run-1"),
+		mk(1*time.Hour, "1.27.0", "13.0.0-200", "passed", "", "run-2"),
+		mk(2*time.Hour, "1.27.1", "13.0.0-200", "failed", "boom", "run-3"),
+		mk(3*time.Hour, "1.27.1", "13.0.0-200", "failed", "boom", "run-4"),
+		mk(4*time.Hour, "1.27.1", "13.0.0-200", "failed", "boom", "run-5"),
+	}
+
+	defects := Analyze(records, RuleConfig{VersionAxis: VersionAxisService}, 24*time.Hour, baseTime)
+	if len(defects) != 1 {
+		t.Fatalf("expected 1 defect keyed on serviceVersion, got %d: %+v", len(defects), defects)
+	}
+	if defects[0].Version != "1.27.1" {
+		t.Errorf("expected version %q, got %q", "1.27.1", defects[0].Version)
+	}
+	if defects[0].PriorPassingVersion != "1.27.0" {
+		t.Errorf("expected prior version %q pooled across the Grafana bump, got %q", "1.27.0", defects[0].PriorPassingVersion)
+	}
+}
+
+func TestAnalyzeServiceVersionAxisSkipsRecordsWithoutServiceVersion(t *testing.T) {
+	// On the service axis, records carrying only a grafanaVersion (e.g. RRC
+	// lines that predate --service-version stamping) must be skipped, not fall
+	// back to the grafana axis. If the failing grafana-only records below
+	// leaked into the block sequence they would sit between the plugin
+	// versions and disqualify the regression boundary, so a fallback flips
+	// this from 1 defect to 0.
+	mkGrafanaOnly := func(offset time.Duration, status, runID string) TestRunRecord {
+		r := mkSvcRun(offset, "", status, "infra noise", runID)
+		r.GrafanaVersion = "13.0.0-999"
+		return r
+	}
+	records := []TestRunRecord{
+		mkSvcRun(0, "1.27.0", "passed", "", "run-1"),
+		mkSvcRun(1*time.Hour, "1.27.0", "passed", "", "run-2"),
+		mkGrafanaOnly(2*time.Hour, "failed", "run-3"),
+		mkGrafanaOnly(3*time.Hour, "failed", "run-4"),
+		mkSvcRun(4*time.Hour, "1.27.1", "failed", "boom", "run-5"),
+		mkSvcRun(5*time.Hour, "1.27.1", "failed", "boom", "run-6"),
+		mkSvcRun(6*time.Hour, "1.27.1", "failed", "boom", "run-7"),
+	}
+
+	defects := Analyze(records, RuleConfig{VersionAxis: VersionAxisService}, 24*time.Hour, baseTime)
+	if len(defects) != 1 {
+		t.Fatalf("expected 1 defect with grafana-only records skipped, got %d: %+v", len(defects), defects)
+	}
+	if defects[0].Version != "1.27.1" {
+		t.Errorf("expected version %q, got %q", "1.27.1", defects[0].Version)
+	}
+	if defects[0].PriorPassingVersion != "1.27.0" {
+		t.Errorf("expected prior version %q, got %q", "1.27.0", defects[0].PriorPassingVersion)
+	}
+}
+
+func TestAnalyzeGrafanaAxisBackCompatFields(t *testing.T) {
+	// Defects on the default axis carry the new axis-neutral fields too, and
+	// GrafanaVersion stays populated for existing consumers.
+	records := []TestRunRecord{
+		mkRun(0, versionGood, "passed", "", "run-1"),
+		mkRun(1*time.Hour, versionGood, "passed", "", "run-2"),
+		mkRun(2*time.Hour, versionBad, "failed", "sig", "run-3"),
+		mkRun(3*time.Hour, versionBad, "failed", "sig", "run-4"),
+		mkRun(4*time.Hour, versionBad, "failed", "sig", "run-5"),
+	}
+
+	defects := Analyze(records, RuleConfig{}, 24*time.Hour, baseTime)
+	if len(defects) != 1 {
+		t.Fatalf("expected 1 defect, got %d: %+v", len(defects), defects)
+	}
+	d := defects[0]
+	if d.GrafanaVersion != versionBad {
+		t.Errorf("expected grafanaVersion %q, got %q", versionBad, d.GrafanaVersion)
+	}
+	if d.Version != versionBad {
+		t.Errorf("expected axis-neutral version %q, got %q", versionBad, d.Version)
+	}
+	if d.VersionAxis != VersionAxisGrafana {
+		t.Errorf("expected versionAxis %q, got %q", VersionAxisGrafana, d.VersionAxis)
+	}
+}
+
 func TestAnalyzeInsufficientPersistence(t *testing.T) {
 	// Only 2 consecutive failures — under the default MinFailures=3.
 	records := []TestRunRecord{

--- a/pkg/analyzer/emitter.go
+++ b/pkg/analyzer/emitter.go
@@ -39,13 +39,29 @@ func DefaultEmitter(svc string) (*Emitter, error) {
 	return NewEmitter(os.Stdout, "json", []any{"tool", "bench", "service", svc})
 }
 
-// EmitDefectConfirmed writes a single msg=defectConfirmed event.
+// EmitDefectConfirmed writes a single msg=defectConfirmed event. The version
+// the rule fired on is carried under an axis-appropriate key — grafanaVersion
+// on the grafana axis (unchanged from v2, so existing RRC dashboards keep
+// working) and serviceVersion on the service axis — with versionAxis emitted
+// as the discriminator. Defects that predate the axis fields emit as the
+// grafana axis.
 func (e *Emitter) EmitDefectConfirmed(d ConfirmedDefect) {
+	axis := d.VersionAxis
+	if axis == "" {
+		axis = VersionAxisGrafana
+	}
 	attrs := []any{
 		"runStage", d.RunStage,
 		"testFile", d.TestFile,
 		"testFolder", d.TestFolder,
-		"grafanaVersion", d.GrafanaVersion,
+		"versionAxis", axis,
+	}
+	if axis == VersionAxisService {
+		attrs = append(attrs, "serviceVersion", d.Version)
+	} else {
+		attrs = append(attrs, "grafanaVersion", d.GrafanaVersion)
+	}
+	attrs = append(attrs,
 		"priorPassingVersion", d.PriorPassingVersion,
 		"grafanaSlug", d.GrafanaSlug,
 		"grafanaUrl", d.GrafanaURL,
@@ -62,7 +78,7 @@ func (e *Emitter) EmitDefectConfirmed(d ConfirmedDefect) {
 		"analyzeWindowSeconds", int(d.AnalyzeWindow.Seconds()),
 		"analyzedAt", d.AnalyzedAt.Format(time.RFC3339),
 		"ruleVersion", d.RuleVersion,
-	}
+	)
 	// The second positional arg to Info mirrors LogReporter.Report's
 	// "suiteRun", "anyFailures", … idiom — slog uses it as the first attribute.
 	e.log.With(attrs...).Info("defectConfirmed", "defectConfirmed", d.SignatureHash)

--- a/pkg/analyzer/emitter_test.go
+++ b/pkg/analyzer/emitter_test.go
@@ -1,0 +1,97 @@
+package analyzer
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func emitOne(t *testing.T, d ConfirmedDefect) map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	e, err := NewEmitter(&buf, "json", []any{"tool", "bench", "service", d.Service})
+	if err != nil {
+		t.Fatalf("building emitter: %v", err)
+	}
+	e.EmitDefectConfirmed(d)
+	var m map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &m); err != nil {
+		t.Fatalf("emitted line not valid JSON: %v\nline: %s", err, buf.String())
+	}
+	return m
+}
+
+func mkDefect(axis, version string) ConfirmedDefect {
+	return ConfirmedDefect{
+		Service:             "grafana-clickhouse-datasource",
+		RunStage:            "ci",
+		TestFile:            "queries.spec.ts",
+		TestFolder:          "tests/e2e",
+		Version:             version,
+		VersionAxis:         axis,
+		PriorPassingVersion: "1.27.0",
+		SignatureHash:       "a9c0f1b2d345",
+		Confidence:          ConfidenceConfirmed,
+		ConfidenceRuns:      3,
+		PriorPassingRuns:    2,
+		FirstFailureTime:    time.Date(2026, 8, 4, 10, 0, 0, 0, time.UTC),
+		LastFailureTime:     time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC),
+		SourceRunIDs:        []string{"run-3", "run-4", "run-5"},
+		AnalyzeWindow:       24 * time.Hour,
+		AnalyzedAt:          time.Date(2026, 8, 4, 13, 0, 0, 0, time.UTC),
+		RuleVersion:         RuleVersion,
+	}
+}
+
+func TestEmitDefectConfirmedServiceAxis(t *testing.T) {
+	m := emitOne(t, mkDefect(VersionAxisService, "1.27.1"))
+
+	if got, _ := m["versionAxis"].(string); got != VersionAxisService {
+		t.Errorf("expected versionAxis=%q, got %q", VersionAxisService, got)
+	}
+	if got, _ := m["serviceVersion"].(string); got != "1.27.1" {
+		t.Errorf("expected serviceVersion=%q, got %q", "1.27.1", got)
+	}
+	if got, _ := m["priorPassingVersion"].(string); got != "1.27.0" {
+		t.Errorf("expected priorPassingVersion=%q, got %q", "1.27.0", got)
+	}
+	if v, ok := m["grafanaVersion"]; ok {
+		t.Errorf("expected no grafanaVersion field on the service axis, got %v", v)
+	}
+}
+
+func TestEmitDefectConfirmedGrafanaAxis(t *testing.T) {
+	d := mkDefect(VersionAxisGrafana, "13.0.0-23542128402")
+	d.GrafanaVersion = d.Version
+	m := emitOne(t, d)
+
+	if got, _ := m["versionAxis"].(string); got != VersionAxisGrafana {
+		t.Errorf("expected versionAxis=%q, got %q", VersionAxisGrafana, got)
+	}
+	if got, _ := m["grafanaVersion"].(string); got != "13.0.0-23542128402" {
+		t.Errorf("expected grafanaVersion=%q, got %q", "13.0.0-23542128402", got)
+	}
+	if v, ok := m["serviceVersion"]; ok {
+		t.Errorf("expected no serviceVersion field on the grafana axis, got %v", v)
+	}
+}
+
+func TestEmitDefectConfirmedLegacyDefectDefaultsToGrafanaAxis(t *testing.T) {
+	// A defect built without the axis fields (any caller predating them) must
+	// emit exactly like the grafana axis so existing dashboards keep working.
+	d := mkDefect("", "")
+	d.Version = ""
+	d.GrafanaVersion = "13.0.0-23542128402"
+	m := emitOne(t, d)
+
+	if got, _ := m["versionAxis"].(string); got != VersionAxisGrafana {
+		t.Errorf("expected versionAxis to default to %q, got %q", VersionAxisGrafana, got)
+	}
+	if got, _ := m["grafanaVersion"].(string); got != "13.0.0-23542128402" {
+		t.Errorf("expected grafanaVersion=%q, got %q", "13.0.0-23542128402", got)
+	}
+	if v, ok := m["serviceVersion"]; ok {
+		t.Errorf("expected no serviceVersion field for a legacy defect, got %v", v)
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -642,6 +642,7 @@ type AnalyzeConfig struct {
 	Window          time.Duration
 	Service         string
 	RunStage        string
+	VersionAxis     string
 	MinFailures     int
 	MinPriorPassing int
 	Emit            bool
@@ -705,11 +706,18 @@ func AddAnalyzeFlags(fs *pflag.FlagSet, cfg *AnalyzeConfig) {
 		3,
 		"Persistence threshold: consecutive failing testRun events required to confirm a defect.",
 	)
+	fs.StringVar(
+		&cfg.VersionAxis,
+		"analyze-version-axis",
+		"grafanaVersion",
+		"Version axis the rule groups and bisects on: 'grafanaVersion' (RRC/core Grafana builds)"+
+			"\nor 'serviceVersion' (the data source plugin version carried from --service-version).",
+	)
 	fs.IntVar(
 		&cfg.MinPriorPassing,
 		"analyze-min-prior-passing",
 		2,
-		"Regression-boundary threshold: passing runs required on the most recent prior grafanaVersion.",
+		"Regression-boundary threshold: passing runs required on the most recent prior distinct version on the analysis axis.",
 	)
 	fs.BoolVar(
 		&cfg.Emit,


### PR DESCRIPTION
## What

Adds `--analyze-version-axis` to `bench analyze` so the defect-confirmation rule can bisect on the data source plugin version (`serviceVersion`, carried from `--service-version`) instead of the Grafana build (`grafanaVersion`, which stays the default).

## Why

Plugin versions move independently of the Grafana version they run against, and datasource `testRun` lines carry no `grafanaVersion` at all, so today the analyzer skips every record on the plugin path and can never confirm a defect. `serviceVersion` is already emitted on every `testRun` line and already parsed by the record type, which keeps this an analyzer-only change. This is the plugin-version extension to #961 called out in the M1 progressive delivery plan for multi-tenant data sources.

## User-facing impact

- New flag `--analyze-version-axis` (default `grafanaVersion`, accepts `serviceVersion`), validated at startup.
- Emitted `msg=defectConfirmed` events now carry a `versionAxis` discriminator. On the new axis the bad version is emitted as `serviceVersion` and `grafanaVersion` is omitted. On the default axis the schema is unchanged apart from the added `versionAxis` field, so existing consumers keep working.
- Dry-run log lines now print `versionAxis` and `version` instead of `grafanaVersion`.

## Notes

- The rule logic (persistence, regression boundary, signature stability, v2 retry confidence) is unchanged. Only the axis it reads is selectable.
- On the `serviceVersion` axis, records without a `serviceVersion` are skipped, mirroring the existing empty-`grafanaVersion` skip. A dedicated test proves records carrying only a `grafanaVersion` cannot leak into the plugin-version block sequence.
- `docs/bench_analyze.md` is regenerated by the cobra doc generator, `docs/analyzing_defects.md` is updated by hand.